### PR TITLE
change urls from GitLab to GitHub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,10 +130,10 @@ We would like to give credits to the following people:
 
 For general discussion, we have a `Gitter chat
 channel <https://gitter.im/python-adaptive/adaptive>`_. If you find any
-bugs or have any feature suggestions please file a GitLab
-`issue <https://gitlab.kwant-project.org/qt/adaptive/issues/new?issue>`_
-or submit a `merge
-request <https://gitlab.kwant-project.org/qt/adaptive/merge_requests>`_.
+bugs or have any feature suggestions please file a GitHub
+`issue <https://github.com/python-adaptive/adaptive/issues/new>`_
+or submit a `pull
+request <https://github.com/python-adaptive/adaptive/pulls>`_.
 
 .. references-start
 .. |logo| image:: https://adaptive.readthedocs.io/en/latest/_static/logo.png

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ The following checks should be made *before* tagging the release.
 #### Check that all issues are resolved
 
 Check that all the issues and merge requests for the appropriate
-[milestone](https://gitlab.kwant-project.org/qt/adaptive/issues)
+[milestone](https://github.com/python-adaptive/adaptive/issues)
 have been resolved. Any unresolved issues should have their milestone
 bumped.
 
@@ -20,7 +20,7 @@ bumped.
 
 For major and minor releases we will be tagging the ``master`` branch.
 This should be as simple as verifying that the
-[latest CI pipeline](https://gitlab.kwant-project.org/qt/adaptive/pipelines)
+[latest CI pipeline](https://dev.azure.com/python-adaptive/adaptive/_build)
 succeeded.
 
 

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -437,7 +437,7 @@ class Learner2D(BaseLearner):
             point_new = tuple(self._unscale(point_new))
 
             # np.clip results in numerical precision problems
-            # https://gitlab.kwant-project.org/qt/adaptive/issues/132
+            # https://github.com/python-adaptive/adaptive/issues/7
             clip = lambda x, l, u: max(l, min(u, x))
             point_new = (clip(point_new[0], *self.bounds[0]),
                          clip(point_new[1], *self.bounds[1]))

--- a/adaptive/tests/test_cquad.py
+++ b/adaptive/tests/test_cquad.py
@@ -68,7 +68,7 @@ def same_ivals(f, a, b, tol):
         return equal_ivals(learner.ivals, ivals, verbose=True)
 
 
-# XXX: This *should* pass (https://gitlab.kwant-project.org/qt/adaptive/issues/84)
+# XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
 @pytest.mark.xfail
 def test_that_gives_same_intervals_as_reference_implementation():
     for i, args in enumerate([[f0, 0, 3, 1e-5],
@@ -157,7 +157,7 @@ def test_adding_points_and_skip_one_point():
     np.testing.assert_almost_equal(learner.igral, learner2.igral)
 
 
-# XXX: This *should* pass (https://gitlab.kwant-project.org/qt/adaptive/issues/84)
+# XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
 @pytest.mark.xfail
 def test_tell_in_random_order(first_add_33=False):
     from operator import attrgetter
@@ -218,7 +218,7 @@ def test_tell_in_random_order(first_add_33=False):
             assert np.isfinite(l.err)
 
 
-# XXX: This *should* pass (https://gitlab.kwant-project.org/qt/adaptive/issues/84)
+# XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
 @pytest.mark.xfail
 def test_tell_in_random_order_first_add_33():
     test_tell_in_random_order(first_add_33=True)
@@ -238,7 +238,7 @@ def test_approximating_intervals():
         assert ivals[i].b == ivals[i + 1].a, (ivals[i], ivals[i + 1])
 
 
-# XXX: This *should* pass (https://gitlab.kwant-project.org/qt/adaptive/issues/43)
+# XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/96)
 @pytest.mark.xfail
 def test_removed_choose_mutiple_points_at_once():
     """Given that a high-precision interval that was split into 2 low-precision ones,

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -9,7 +9,7 @@ from adaptive.runner import simple
 
 
 def test_pending_loss_intervals():
-    # https://gitlab.kwant-project.org/qt/adaptive/issues/99
+    # https://github.com/python-adaptive/adaptive/issues/40
     l = Learner1D(lambda x: x, (0, 4))
 
     l.tell(0, 0)
@@ -24,7 +24,7 @@ def test_pending_loss_intervals():
 
 
 def test_loss_interpolation_for_unasked_point():
-    # https://gitlab.kwant-project.org/qt/adaptive/issues/99
+    # https://github.com/python-adaptive/adaptive/issues/40
     l = Learner1D(lambda x: x, (0, 4))
 
     l.tell(0, 0)
@@ -127,7 +127,7 @@ def test_termination_on_discontinuities():
 
 
 def test_order_adding_points():
-    # and https://gitlab.kwant-project.org/qt/adaptive/issues/98
+    # and https://github.com/python-adaptive/adaptive/issues/41
     l = Learner1D(lambda x: x, (0, 1))
     l.tell_many([1, 0, 0.5], [0, 0, 0])
     assert l.losses_combined == {(0, 0.5): 0.5, (0.5, 1): 0.5}
@@ -136,7 +136,7 @@ def test_order_adding_points():
 
 
 def test_adding_existing_point_passes_silently():
-    # See https://gitlab.kwant-project.org/qt/adaptive/issues/97
+    # See https://github.com/python-adaptive/adaptive/issues/42
     l = Learner1D(lambda x: x, (0, 4))
     l.tell(0, 0)
     l.tell(1, 0)
@@ -167,7 +167,7 @@ def small_deviations(x):
 def test_small_deviations():
     """This tests whether the Learner1D can handle small deviations.
     See https://gitlab.kwant-project.org/qt/adaptive/merge_requests/73 and
-    https://gitlab.kwant-project.org/qt/adaptive/issues/61."""
+    https://github.com/python-adaptive/adaptive/issues/78."""
 
     eps = 5e-14
     learner = Learner1D(small_deviations, bounds=(1 - eps, 1 + eps))
@@ -221,7 +221,7 @@ def test_uniform_sampling1D_v2():
 
 
 def test_add_data_unordered():
-    # see https://gitlab.kwant-project.org/qt/adaptive/issues/95
+    # see https://github.com/python-adaptive/adaptive/issues/44
     learner = Learner1D(lambda x: x, bounds=(-1, 1))
     xs = [-1, 1, 0]
 

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -263,7 +263,7 @@ def test_adding_existing_data_is_idempotent(learner_type, f, learner_kwargs):
     assert set(pls) == set(cpls)
 
 
-# XXX: This *should* pass (https://gitlab.kwant-project.org/qt/adaptive/issues/84)
+# XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
 #      but we xfail it now, as Learner2D will be deprecated anyway
 @run_with(Learner1D, xfail(Learner2D), LearnerND, AverageLearner)
 def test_adding_non_chosen_data(learner_type, f, learner_kwargs):
@@ -336,7 +336,7 @@ def test_point_adding_order_is_irrelevant(learner_type, f, learner_kwargs):
 
 
 # XXX: the Learner2D fails with ~50% chance
-# see https://gitlab.kwant-project.org/qt/adaptive/issues/84
+# see https://github.com/python-adaptive/adaptive/issues/55
 @run_with(Learner1D, xfail(Learner2D), LearnerND, AverageLearner)
 def test_expected_loss_improvement_is_less_than_total_loss(learner_type, f, learner_kwargs):
     """The estimated loss improvement can never be greater than the total loss."""
@@ -360,7 +360,7 @@ def test_expected_loss_improvement_is_less_than_total_loss(learner_type, f, lear
         assert sum(loss_improvements) < learner.loss()
 
 
-# XXX: This *should* pass (https://gitlab.kwant-project.org/qt/adaptive/issues/84)
+# XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
 #      but we xfail it now, as Learner2D will be deprecated anyway
 @run_with(Learner1D, xfail(Learner2D), LearnerND)
 def test_learner_performance_is_invariant_under_scaling(learner_type, f, learner_kwargs):

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -41,7 +41,7 @@ def test_simple(runner):
 def test_nonconforming_output(runner):
     """Test that using a runner works with a 2D learner, even when the
     learned function outputs a 1-vector. This tests against the regression
-    flagged in https://gitlab.kwant-project.org/qt/adaptive/issues/58.
+    flagged in https://github.com/python-adaptive/adaptive/issues/81.
     """
 
     def f(x):

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,12 +1,12 @@
 {
     "version": 1,
     "project": "adaptive",
-    "project_url": "https://gitlab.kwant-project.org/qt/adaptive",
+    "project_url": "https://github.com/python-adaptive/adaptive",
     "repo": "..",
     "dvcs": "git",
     "environment_type": "conda",
     "install_timeout": 600,
-    "show_commit_url": "https://gitlab.kwant-project.org/qt/adaptive/commit/",
+    "show_commit_url": "https://github.com/python-adaptive/adaptive/commits/",
     "pythons": ["3.6"],
     "conda_channels": ["conda-forge"],
     "matrix": {

--- a/docs/source/tutorial/tutorial.rst
+++ b/docs/source/tutorial/tutorial.rst
@@ -1,7 +1,7 @@
 Tutorial Adaptive
 =================
 
-`Adaptive <https://gitlab.kwant-project.org/qt/adaptive-evaluation>`__
+`Adaptive <https://github.com/python-adaptive/adaptive>`__
 is a package for adaptively sampling functions with support for parallel
 evaluation.
 

--- a/learner.ipynb
+++ b/learner.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[`adaptive`](https://gitlab.kwant-project.org/qt/adaptive-evaluation) is a package for adaptively sampling functions with support for parallel evaluation.\n",
+    "[`adaptive`](https://github.com/python-adaptive/adaptive) is a package for adaptively sampling functions with support for parallel evaluation.\n",
     "\n",
     "This is an introductory notebook that shows some basic use cases.\n",
     "\n",


### PR DESCRIPTION
I've changed all mentions of GitLab to GitHub.

We used [this](https://github.com/python-adaptive/adaptive/issues/5#issuecomment-448708930) script to transfer all open and closed issues to GitHub and all open PRs from GitLab to GitHub.