### PR TITLE
invoke conda directly in CI

### DIFF
--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -101,6 +101,7 @@ def test_ipyparallel_executor(ipyparallel_executor):
     assert learner.npoints > 0
 
 
+@pytest.mark.timeout(60)
 @pytest.mark.skipif(not with_distributed, reason='dask.distributed is not installed')
 def test_distributed_executor(dask_executor):
     learner = Learner1D(linear, (-1, 1))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,22 +1,12 @@
 steps:
-- task: CondaEnvironment@1
-  inputs:
-    packageSpecs: >
-      python=3.6
-      sortedcontainers
-      sortedcollections
-      scipy
-      holoviews
-      ipyparallel
-      distributed
-      ipykernel>=4.8*
-      jupyter_client>=5.2.2
-      ipywidgets
-      scikit-optimize
-      plotly
-    createCustomEnvironment: true
-    createOptions: "-c conda-forge"
-    environmentName: 'adaptive'
+- bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
+  displayName: Add conda to PATH
+
+- bash: sudo chown -R $USER /usr/share/miniconda
+  displayName: Take ownership of conda installation
+
+- script: conda env update --name root --quiet --file environment.yml
+  displayName: Create conda environment
 
 - script: pip install -r test-requirements.txt
   displayName: 'Install test-requirements.txt'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,16 +2,17 @@ steps:
 - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
   displayName: Add conda to PATH
 
-- bash: sudo chown -R $USER /usr/share/miniconda
-  displayName: Take ownership of conda installation
+- script: conda env create --quiet --file environment.yml
+  displayName: Create Anaconda environment
 
-- script: conda env update --name root --quiet --file environment.yml
-  displayName: Create conda environment
-
-- script: pip install -r test-requirements.txt
+- script: |
+    source activate adaptive
+    pip install -r test-requirements.txt
   displayName: 'Install test-requirements.txt'
 
-- script: py.test --verbose --cov=adaptive --cov-report term --cov-report html adaptive
+- script: |
+    source activate adaptive
+    py.test --verbose --cov=adaptive --cov-report term --cov-report html adaptive
   displayName: 'Run the tests'
 
 - script: |

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
-pytest
-pytest-randomly
-pytest-cov
 pexpect
+pytest
+pytest-cov
+pytest-randomly
+pytest-timeout


### PR DESCRIPTION
The Conda Environment task is deprecated
https://github.com/Microsoft/azure-pipelines-tasks/pull/9573

Example uses are [here](https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/anaconda?view=azure-devops&tabs=ubuntu-16-04).