### PR TITLE
import Iterable and Sized from collections.abc

### DIFF
--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from collections import defaultdict, Iterable
+from collections import defaultdict
+from collections.abc import Iterable
 from contextlib import suppress
 from functools import partial
 from operator import itemgetter

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -20,7 +20,7 @@ def dispatch(child_functions, arg):
 
 
 class BalancingLearner(BaseLearner):
-    """Choose the optimal points from a set of learners.
+    r"""Choose the optimal points from a set of learners.
 
     Parameters
     ----------

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 import heapq
 import itertools
 import math
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import sortedcontainers

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from collections import OrderedDict, Iterable
+from collections import OrderedDict
+from collections.abc import Iterable
 import functools
 import heapq
 import itertools

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -1,4 +1,5 @@
-from collections import Counter, Sized, Iterable
+from collections import Counter
+from collections.abc import Sized, Iterable
 from itertools import combinations, chain
 
 import numpy as np


### PR DESCRIPTION
Because of the following DeprecationWarning:
```
DeprecationWarning: Using or importing the ABCs from 'collections'
instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
