### PR TITLE
test flat bands in the LearnerND

### DIFF
--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -551,7 +551,7 @@ class LearnerND(BaseLearner):
 
         self._output_multiplier = scale_multiplier
 
-        scale_factor = np.max(np.nan_to_num(self._scale / self._old_scale))
+        scale_factor = np.max(self._scale / self._old_scale)
         if scale_factor > self._recompute_losses_factor:
             self._old_scale = self._scale
             self._recompute_all_losses()

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -483,7 +483,7 @@ class LearnerND(BaseLearner):
 
         # scale them to a cube with sides 1
         vertices = vertices @ self._transform
-        values = self._output_multiplier * values
+        values = self._output_multiplier * np.array(values)
 
         # compute the loss on the scaled simplex
         return float(self.loss_per_simplex(vertices, values))
@@ -513,40 +513,38 @@ class LearnerND(BaseLearner):
     @property
     def _scale(self):
         # get the output scale
-        return np.max(self._max_value - self._min_value)
+        return self._max_value - self._min_value
 
     def _update_range(self, new_output):
         if self._min_value is None or self._max_value is None:
             # this is the first point, nothing to do, just set the range
-            self._min_value = np.array(new_output)
-            self._max_value = np.array(new_output)
+            self._min_value = np.min(new_output)
+            self._max_value = np.max(new_output)
             self._old_scale = self._scale or 1
             return False
 
         # if range in one or more directions is doubled, then update all losses
-        self._min_value = np.minimum(self._min_value, new_output)
-        self._max_value = np.maximum(self._max_value, new_output)
+        self._min_value = min(self._min_value, np.min(new_output))
+        self._max_value = max(self._max_value, np.max(new_output))
 
         scale_multiplier = 1 / (self._scale or 1)
-        if isinstance(scale_multiplier, float):
-            scale_multiplier = np.array([scale_multiplier], dtype=float)
 
         # the maximum absolute value that is in the range. Because this is the
         # largest number, this also has the largest absolute numerical error.
-        max_absolute_value_in_range = np.max(np.abs([self._min_value, self._max_value]))
+        max_absolute_value_in_range = max(abs(self._min_value),
+                                          abs(self._max_value))
         # since a float has a relative error of 1e-15, the absolute error is the value * 1e-15
         abs_err = 1e-15 * max_absolute_value_in_range
         # when scaling the floats, the error gets increased.
         scaled_err = abs_err * scale_multiplier
 
-        allowed_numerical_error = 1e-2
-
         # do not scale along the axis if the numerical error gets too big
-        scale_multiplier[scaled_err > allowed_numerical_error] = 1
+        if scaled_err > 1e-2:  # allowed_numerical_error = 1e-2
+            scale_multiplier = 1
 
         self._output_multiplier = scale_multiplier
 
-        scale_factor = np.max(self._scale / self._old_scale)
+        scale_factor = self._scale / self._old_scale
         if scale_factor > self._recompute_losses_factor:
             self._old_scale = self._scale
             self._recompute_all_losses()

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -513,7 +513,12 @@ class LearnerND(BaseLearner):
     @property
     def _scale(self):
         # get the output scale
-        return self._max_value - self._min_value
+        scale = self._max_value - self._min_value
+        if isinstance(scale, np.ndarray):
+            scale[scale == 0] = 1
+        elif scale == 0:
+            scale = 1
+        return scale
 
     def _update_range(self, new_output):
         if self._min_value is None or self._max_value is None:

--- a/adaptive/tests/test_learnernd.py
+++ b/adaptive/tests/test_learnernd.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import numpy as np
 import scipy.spatial
 
 from adaptive.learner import LearnerND
@@ -38,3 +39,14 @@ def test_interior_vs_bbox_gives_same_result():
     simple(learner, goal=lambda l: l.loss() < 0.1)
 
     assert learner.data == control.data
+
+
+def test_vector_return_with_a_flat_layer():
+    f = generate_random_parametrization(ring_of_fire)
+    g = generate_random_parametrization(ring_of_fire)
+    h1 = lambda xy: np.array([f(xy), g(xy)])
+    h2 = lambda xy: np.array([f(xy), 0*g(xy)])
+    h3 = lambda xy: np.array([0*f(xy), g(xy)])
+    for function in [h1, h2, h3]:
+        learner = LearnerND(function, bounds=[(-1, 1), (-1, 1)])
+        simple(learner, goal=lambda l: l.loss() < 0.1)


### PR DESCRIPTION
The test that I added fails (or not really fails but continues forever).

I stumbled upon this when trying to fix the the following `Warnings` : 
```python
adaptive/tests/test_learnernd.py::test_faiure_case_LearnerND
adaptive/tests/test_learnernd.py::test_interior_vs_bbox_gives_same_result
  /Users/basnijholt/Work/adaptive/adaptive/learner/learnerND.py:529: RuntimeWarning: divide by zero encountered in double_scalars
    scale_multiplier = 1 / self._scale

adaptive/tests/test_learnernd.py::test_faiure_case_LearnerND
adaptive/tests/test_learnernd.py::test_interior_vs_bbox_gives_same_result
  /Users/basnijholt/Work/adaptive/adaptive/learner/learnerND.py:548: RuntimeWarning: invalid value encountered in double_scalars
    scale_factor = np.max(np.nan_to_num(self._scale / self._old_scale))

adaptive/tests/test_learnernd.py::test_faiure_case_LearnerND
adaptive/tests/test_learnernd.py::test_interior_vs_bbox_gives_same_result
  /Users/basnijholt/Work/adaptive/adaptive/learner/learnerND.py:548: RuntimeWarning: divide by zero encountered in double_scalars
    scale_factor = np.max(np.nan_to_num(self._scale / self._old_scale))
```