### PR TITLE
do not inline the HoloViews JS

### DIFF
--- a/adaptive/notebook_integration.py
+++ b/adaptive/notebook_integration.py
@@ -14,7 +14,7 @@ _ipywidgets_enabled = False
 _plotly_enabled = False
 
 
-def notebook_extension():
+def notebook_extension(*, _inline_js=True):
     """Enable ipywidgets, holoviews, and asyncio notebook integration."""
     if not in_ipynb():
         raise RuntimeError('"adaptive.notebook_extension()" may only be run '
@@ -27,7 +27,7 @@ def notebook_extension():
         _holoviews_enabled = False  # After closing a notebook the js is gone
         if not _holoviews_enabled:
             import holoviews
-            holoviews.notebook_extension('bokeh', logo=False)
+            holoviews.notebook_extension('bokeh', logo=False, inline=_inline_js)
             _holoviews_enabled = True
     except ModuleNotFoundError:
         warnings.warn("holoviews is not installed; plotting "

--- a/docs/source/docs.rst
+++ b/docs/source/docs.rst
@@ -48,7 +48,7 @@ on the *Play* :fa:`play` button or move the sliders.
     from adaptive.learner.learner1D import uniform_loss, default_loss
     import holoviews as hv
     import numpy as np
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
     %output holomap='scrubber'
 
 `adaptive.Learner1D`

--- a/docs/source/tutorial/tutorial.AverageLearner.rst
+++ b/docs/source/tutorial/tutorial.AverageLearner.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.AverageLearner`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
 The next type of learner averages a function until the uncertainty in
 the average meets some condition.

--- a/docs/source/tutorial/tutorial.BalancingLearner.rst
+++ b/docs/source/tutorial/tutorial.BalancingLearner.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.BalancingLearner`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     import holoviews as hv
     import numpy as np

--- a/docs/source/tutorial/tutorial.DataSaver.rst
+++ b/docs/source/tutorial/tutorial.DataSaver.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.DataSaver`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
 If the function that you want to learn returns a value along with some
 metadata, you can wrap your learner in an `adaptive.DataSaver`.

--- a/docs/source/tutorial/tutorial.IntegratorLearner.rst
+++ b/docs/source/tutorial/tutorial.IntegratorLearner.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.IntegratorLearner`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     import holoviews as hv
     import numpy as np

--- a/docs/source/tutorial/tutorial.Learner1D.rst
+++ b/docs/source/tutorial/tutorial.Learner1D.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.Learner1D`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     import numpy as np
     from functools import partial

--- a/docs/source/tutorial/tutorial.Learner2D.rst
+++ b/docs/source/tutorial/tutorial.Learner2D.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.Learner2D`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     import numpy as np
     from functools import partial

--- a/docs/source/tutorial/tutorial.LearnerND.rst
+++ b/docs/source/tutorial/tutorial.LearnerND.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.LearnerND`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     import holoviews as hv
     import numpy as np

--- a/docs/source/tutorial/tutorial.SKOptLearner.rst
+++ b/docs/source/tutorial/tutorial.SKOptLearner.rst
@@ -14,7 +14,7 @@ Tutorial `~adaptive.SKOptLearner`
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     import holoviews as hv
     import numpy as np

--- a/docs/source/tutorial/tutorial.advanced-topics.rst
+++ b/docs/source/tutorial/tutorial.advanced-topics.rst
@@ -14,7 +14,7 @@ Advanced Topics
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     import asyncio
     from functools import partial

--- a/docs/source/tutorial/tutorial.custom_loss.rst
+++ b/docs/source/tutorial/tutorial.custom_loss.rst
@@ -14,7 +14,7 @@ Custom adaptive logic for 1D and 2D
     :hide-code:
 
     import adaptive
-    adaptive.notebook_extension()
+    adaptive.notebook_extension(_inline_js=False)
 
     # Import modules that are used in multiple cells
     import numpy as np


### PR DESCRIPTION
This reduces the size of the `html` folder of 93.3 MB (master) to 60.1 MB (this branch).


Related: https://github.com/pyviz/holoviews/pull/3581