### PR TITLE
use the repo code in docs execute

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -17,6 +17,5 @@ dependencies:
     - ipywidgets
     - scikit-optimize
     - git+https://github.com/basnijholt/jupyter-sphinx.git@widgets_execute
-    - git+https://github.com/python-adaptive/adaptive.git@master  # temporary solution because jupyter-sphinx doesn't use the adaptive from the repo
     - sphinx_fontawesome
     - m2r


### PR DESCRIPTION
~~~Related https://github.com/jupyter-widgets/jupyter-sphinx/pull/27 and https://github.com/jupyter-widgets/jupyter-sphinx/issues/26.~~~

edit:
In the readthedocs.org settings we enabled to install the repo code.