### PR TITLE
use setup(..., python_requires='>=3.6'), closes #179

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     name='adaptive',
     description='Adaptive parallel sampling of mathematical functions',
     version=version,
+    python_requires='>=3.6',
     url='https://adaptive.readthedocs.io/',
     author='Adaptive authors',
     license='BSD',


### PR DESCRIPTION
As by the suggestion of @Carreau in #179.