### PR TITLE
BalancingLearner: add a "cycle" strategy, sampling the learners one by one

### DIFF
--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -51,7 +51,7 @@ class BalancingLearner(BaseLearner):
     function : callable
         A function that calls the functions of the underlying learners.
         Its signature is ``function(learner_index, point)``.
-    strategy : 'loss_improvements' (default), 'loss', or 'npoints'
+    strategy : 'loss_improvements' (default), 'loss', 'npoints', or 'cycle'.
         The points that the `BalancingLearner` choses can be either based on:
         the best 'loss_improvements', the smallest total 'loss' of the
         child learners, the number of points per learner, using 'npoints',
@@ -112,6 +112,7 @@ class BalancingLearner(BaseLearner):
             self._ask_and_tell = self._ask_and_tell_based_on_npoints
         elif strategy == "cycle":
             self._ask_and_tell = self._ask_and_tell_based_on_cycle
+            self._cycle = itertools.cycle(range(len(self.learners)))
         else:
             raise ValueError(
                 'Only strategy="loss_improvements", strategy="loss",'
@@ -179,9 +180,6 @@ class BalancingLearner(BaseLearner):
         return points, loss_improvements
 
     def _ask_and_tell_based_on_cycle(self, n):
-        if not hasattr(self, "_cycle"):
-            self._cycle = itertools.cycle(range(len(self.learners)))
-
         points, loss_improvements = [], []
         for _ in range(n):
             index = next(self._cycle)

--- a/adaptive/tests/test_balancing_learner.py
+++ b/adaptive/tests/test_balancing_learner.py
@@ -6,6 +6,9 @@ from adaptive.learner import BalancingLearner, Learner1D
 from adaptive.runner import simple
 
 
+strategies = ["loss", "loss_improvements", "npoints", "cycle"]
+
+
 def test_balancing_learner_loss_cache():
     learner = Learner1D(lambda x: x, bounds=(-1, 1))
     learner.tell(-1, -1)
@@ -26,7 +29,7 @@ def test_balancing_learner_loss_cache():
     assert bl.loss(real=True) == real_loss
 
 
-@pytest.mark.parametrize("strategy", ["loss", "loss_improvements", "npoints"])
+@pytest.mark.parametrize("strategy", strategies)
 def test_distribute_first_points_over_learners(strategy):
     for initial_points in [0, 3]:
         learners = [Learner1D(lambda x: x, bounds=(-1, 1)) for i in range(10)]
@@ -41,7 +44,7 @@ def test_distribute_first_points_over_learners(strategy):
         assert len(set(i_learner)) == len(learners)
 
 
-@pytest.mark.parametrize("strategy", ["loss", "loss_improvements", "npoints"])
+@pytest.mark.parametrize("strategy", strategies)
 def test_ask_0(strategy):
     learners = [Learner1D(lambda x: x, bounds=(-1, 1)) for i in range(10)]
     learner = BalancingLearner(learners, strategy=strategy)
@@ -55,6 +58,7 @@ def test_ask_0(strategy):
         ("loss", lambda l: l.loss() < 0.1),
         ("loss_improvements", lambda l: l.loss() < 0.1),
         ("npoints", lambda bl: all(l.npoints > 10 for l in bl.learners)),
+        ("cycle", lambda l: l.loss() < 0.1),
     ],
 )
 def test_strategies(strategy, goal):


### PR DESCRIPTION
This is useful for example for the `AverageLearner1D` and `2D` where sampling on `npoints` won't sample all learners equally, because that's not how `npoints` is defined there.