### PR TITLE
use pytest rather than py.test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ steps:
 
 - script: |
     source activate adaptive
-    py.test --verbose --cov=adaptive --cov-report term --cov-report html adaptive
+    pytest --verbose --cov=adaptive --cov-report term --cov-report html adaptive
   displayName: 'Run the tests'
 
 - script: |


### PR DESCRIPTION
It's been a while since `pytest` command exists (pytest 3.0.0 released in August 2016). From [this](https://docs.pytest.org/en/latest/changelog.html#id760):
> Introduce pytest command as recommended entry point. Note that py.test still works and is not scheduled for removal.