### PR TITLE
Add a SequenceLearner

### DIFF
--- a/adaptive/__init__.py
+++ b/adaptive/__init__.py
@@ -14,6 +14,7 @@ from adaptive.learner import (
     Learner2D,
     LearnerND,
     make_datasaver,
+    SequenceLearner,
 )
 from adaptive.notebook_integration import (
     active_plotting_tasks,
@@ -36,6 +37,7 @@ __all__ = [
     "Learner2D",
     "LearnerND",
     "make_datasaver",
+    "SequenceLearner",
     "active_plotting_tasks",
     "live_plot",
     "notebook_extension",

--- a/adaptive/learner/__init__.py
+++ b/adaptive/learner/__init__.py
@@ -10,6 +10,7 @@ from adaptive.learner.integrator_learner import IntegratorLearner
 from adaptive.learner.learner1D import Learner1D
 from adaptive.learner.learner2D import Learner2D
 from adaptive.learner.learnerND import LearnerND
+from adaptive.learner.sequence_learner import SequenceLearner
 
 __all__ = [
     "AverageLearner",
@@ -21,6 +22,7 @@ __all__ = [
     "Learner1D",
     "Learner2D",
     "LearnerND",
+    "SequenceLearner",
 ]
 
 with suppress(ImportError):

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -1,0 +1,82 @@
+from copy import copy
+import sys
+
+from adaptive.learner.base_learner import BaseLearner
+
+inf = sys.float_info.max
+
+
+def ensure_hashable(x):
+    try:
+        hash(x)
+        return x
+    except TypeError:
+        return tuple(x)
+
+
+class SequenceLearner(BaseLearner):
+    def __init__(self, function, sequence):
+        self.function = function
+        self._to_do_seq = {ensure_hashable(x) for x in sequence}
+        self._npoints = len(sequence)
+        self.sequence = copy(sequence)
+        self.data = {}
+        self.pending_points = set()
+
+    def ask(self, n, tell_pending=True):
+        points = []
+        loss_improvements = []
+        i = 0
+        for point in self._to_do_seq:
+            if i > n:
+                break
+            points.append(point)
+            loss_improvements.append(inf / self._npoints)
+            i += 1
+
+        if tell_pending:
+            for p in points:
+                self.tell_pending(p)
+
+        return points, loss_improvements
+
+    def _get_data(self):
+        return self.data
+
+    def _set_data(self, data):
+        if data:
+            self.tell_many(*zip(*data.items()))
+
+    def loss(self, real=True):
+        if not (self._to_do_seq or self.pending_points):
+            return 0
+        else:
+            npoints = self.npoints + (0 if real else len(self.pending_points))
+            return inf / npoints
+
+    def remove_unfinished(self):
+        for p in self.pending_points:
+            self._to_do_seq.add(p)
+        self.pending_points = set()
+
+    def tell(self, point, value):
+        self.data[point] = value
+        self.pending_points.discard(point)
+        self._to_do_seq.discard(point)
+
+    def tell_pending(self, point):
+        self.pending_points.add(point)
+        self._to_do_seq.discard(point)
+
+    def done(self):
+        return not self._to_do_seq and not self.pending_points
+
+    def result(self):
+        """Get back the data in the same order as ``sequence``."""
+        if not self.done():
+            raise Exception("Learner is not yet complete.")
+        return [self.data[ensure_hashable(x)] for x in self.sequence]
+
+    @property
+    def npoints(self):
+        return len(self.data)

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -52,7 +52,7 @@ class SequenceLearner(BaseLearner):
     Notes
     -----
     From primitive tests, the `~adaptive.SequenceLearner` appears to have a
-    similar performance to `ipyparallel`\s `load_balanced_view().map`. With
+    similar performance to `ipyparallel`\s ``load_balanced_view().map``. With
     the added benefit of having results in the local kernel already.
     """
 
@@ -120,7 +120,7 @@ class SequenceLearner(BaseLearner):
         return not self._to_do_indices and not self.pending_points
 
     def result(self):
-        """Get back the data in the same order as ``sequence``."""
+        """Get the function values in the same order as ``sequence``."""
         if not self.done():
             raise Exception("Learner is not yet complete.")
         return list(self.data.values())

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -33,6 +33,25 @@ class _IgnoreFirstArgument:
 
 
 class SequenceLearner(BaseLearner):
+    """A learner that will learn a sequence.
+
+    This is useful when your problem cannot be formulated in terms of
+    another adaptive learner, but you still want to use Adaptive's
+    routines to run, save, and plot.
+
+    Parameters
+    ----------
+    function : callable
+        The function to learn. Must take a single element `sequence`.
+    sequence : sequence
+        The sequence to learn.
+
+    Attributes
+    ----------
+    data : dict
+        The data as a mapping from "index of element in sequence" => value.
+    """
+
     def __init__(self, function, sequence):
         self._original_function = function
         self.function = _IgnoreFirstArgument(function)
@@ -65,7 +84,10 @@ class SequenceLearner(BaseLearner):
 
     def _set_data(self, data):
         if data:
-            self.tell_many(*zip(*data.items()))
+            indices, values = zip(*data.items())
+            # the points aren't used by tell, so we can safely pass None
+            points = [(i, None) for i in indices]
+            self.tell_many(points, values)
 
     def loss(self, real=True):
         if not (self._to_do_indices or self.pending_points):

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -1,5 +1,6 @@
-from copy import copy
 import sys
+import warnings
+from copy import copy
 
 from adaptive.learner.base_learner import BaseLearner
 
@@ -11,7 +12,13 @@ def ensure_hashable(x):
         hash(x)
         return x
     except TypeError:
-        return tuple(x)
+        msg = "The items in `sequence` need to be hashable, {}. Make sure you reflect this in your function."
+        if isinstance(x, dict):
+            warnings.warn(msg.format("we converted `dict` to `tuple(dict.items())`"))
+            return tuple(x.items())
+        else:
+            warnings.warn(msg.format("we tried to cast the items to a tuple"))
+            return tuple(x)
 
 
 class SequenceLearner(BaseLearner):
@@ -26,13 +33,11 @@ class SequenceLearner(BaseLearner):
     def ask(self, n, tell_pending=True):
         points = []
         loss_improvements = []
-        i = 0
         for point in self._to_do_seq:
-            if i > n:
+            if len(points) >= n:
                 break
             points.append(point)
             loss_improvements.append(inf / self._npoints)
-            i += 1
 
         if tell_pending:
             for p in points:

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -59,7 +59,8 @@ class SequenceLearner(BaseLearner):
             return 0
         else:
             npoints = self.npoints + (0 if real else len(self.pending_points))
-            return inf / npoints
+            ntotal = len(self.sequence)
+            return (ntotal - npoints) / ntotal
 
     def remove_unfinished(self):
         for p in self.pending_points:

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -27,7 +27,7 @@ class SequenceLearner(BaseLearner):
 
         # We use a poor man's OrderedSet, a dict that points to None.
         self._to_do_seq = {ensure_hashable(x): None for x in sequence}
-        self._npoints = len(sequence)
+        self._ntotal = len(sequence)
         self.sequence = copy(sequence)
         self.data = {}
         self.pending_points = set()
@@ -39,7 +39,7 @@ class SequenceLearner(BaseLearner):
             if len(points) >= n:
                 break
             points.append(point)
-            loss_improvements.append(inf / self._npoints)
+            loss_improvements.append(1 / self._ntotal)
 
         if tell_pending:
             for p in points:
@@ -59,8 +59,7 @@ class SequenceLearner(BaseLearner):
             return 0
         else:
             npoints = self.npoints + (0 if real else len(self.pending_points))
-            ntotal = len(self.sequence)
-            return (ntotal - npoints) / ntotal
+            return (self._ntotal - npoints) / self._ntotal
 
     def remove_unfinished(self):
         for p in self.pending_points:

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -1,7 +1,7 @@
 import sys
 from copy import copy
 
-from sortedcontainers import SortedSet
+from sortedcontainers import SortedSet, SortedDict
 
 from adaptive.learner.base_learner import BaseLearner
 
@@ -39,7 +39,7 @@ class SequenceLearner(BaseLearner):
         self._to_do_indices = SortedSet({i for i, _ in enumerate(sequence)})
         self._ntotal = len(sequence)
         self.sequence = copy(sequence)
-        self.data = {}
+        self.data = SortedDict()
         self.pending_points = set()
 
     def ask(self, n, tell_pending=True):
@@ -97,7 +97,7 @@ class SequenceLearner(BaseLearner):
         """Get back the data in the same order as ``sequence``."""
         if not self.done():
             raise Exception("Learner is not yet complete.")
-        return [self.data[i] for i, _ in enumerate(self.sequence)]
+        return list(self.data.values())
 
     @property
     def npoints(self):

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -1,11 +1,8 @@
-import sys
 from copy import copy
 
 from sortedcontainers import SortedSet, SortedDict
 
 from adaptive.learner.base_learner import BaseLearner
-
-inf = sys.float_info.max
 
 
 class _IgnoreFirstArgument:
@@ -33,7 +30,8 @@ class _IgnoreFirstArgument:
 
 
 class SequenceLearner(BaseLearner):
-    r"""A learner that will learn a sequence.
+    r"""A learner that will learn a sequence. It simply returns
+    the points in the provided sequence when asked.
 
     This is useful when your problem cannot be formulated in terms of
     another adaptive learner, but you still want to use Adaptive's

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -24,7 +24,9 @@ def ensure_hashable(x):
 class SequenceLearner(BaseLearner):
     def __init__(self, function, sequence):
         self.function = function
-        self._to_do_seq = {ensure_hashable(x) for x in sequence}
+
+        # We use a poor man's OrderedSet, a dict that points to None.
+        self._to_do_seq = {ensure_hashable(x): None for x in sequence}
         self._npoints = len(sequence)
         self.sequence = copy(sequence)
         self.data = {}
@@ -61,17 +63,17 @@ class SequenceLearner(BaseLearner):
 
     def remove_unfinished(self):
         for p in self.pending_points:
-            self._to_do_seq.add(p)
+            self._to_do_seq[p] = None
         self.pending_points = set()
 
     def tell(self, point, value):
         self.data[point] = value
         self.pending_points.discard(point)
-        self._to_do_seq.discard(point)
+        self._to_do_seq.pop(point, None)
 
     def tell_pending(self, point):
         self.pending_points.add(point)
-        self._to_do_seq.discard(point)
+        self._to_do_seq.pop(point, None)
 
     def done(self):
         return not self._to_do_seq and not self.pending_points

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -33,7 +33,7 @@ class _IgnoreFirstArgument:
 
 
 class SequenceLearner(BaseLearner):
-    """A learner that will learn a sequence.
+    r"""A learner that will learn a sequence.
 
     This is useful when your problem cannot be formulated in terms of
     another adaptive learner, but you still want to use Adaptive's
@@ -50,6 +50,12 @@ class SequenceLearner(BaseLearner):
     ----------
     data : dict
         The data as a mapping from "index of element in sequence" => value.
+
+    Notes
+    -----
+    From primitive tests, the `~adaptive.SequenceLearner` appears to have a
+    similar performance to `ipyparallel`\s `load_balanced_view().map`. With
+    the added benefit of having results in the local kernel already.
     """
 
     def __init__(self, function, sequence):

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -24,6 +24,7 @@ from adaptive.learner import (
     Learner1D,
     Learner2D,
     LearnerND,
+    SequenceLearner,
 )
 from adaptive.runner import simple
 
@@ -116,6 +117,7 @@ def quadratic(x, m: uniform(0, 10), b: uniform(0, 1)):
 
 
 @learn_with(Learner1D, bounds=(-1, 1))
+@learn_with(SequenceLearner, sequence=np.linspace(-1, 1, 201))
 def linear_with_peak(x, d: uniform(-1, 1)):
     a = 0.01
     return x + a ** 2 / (a ** 2 + (x - d) ** 2)
@@ -123,6 +125,7 @@ def linear_with_peak(x, d: uniform(-1, 1)):
 
 @learn_with(LearnerND, bounds=((-1, 1), (-1, 1)))
 @learn_with(Learner2D, bounds=((-1, 1), (-1, 1)))
+@learn_with(SequenceLearner, sequence=np.random.rand(1000, 2))
 def ring_of_fire(xy, d: uniform(0.2, 1)):
     a = 0.2
     x, y = xy
@@ -130,12 +133,14 @@ def ring_of_fire(xy, d: uniform(0.2, 1)):
 
 
 @learn_with(LearnerND, bounds=((-1, 1), (-1, 1), (-1, 1)))
+@learn_with(SequenceLearner, sequence=np.random.rand(1000, 3))
 def sphere_of_fire(xyz, d: uniform(0.2, 1)):
     a = 0.2
     x, y, z = xyz
     return x + math.exp(-(x ** 2 + y ** 2 + z ** 2 - d ** 2) ** 2 / a ** 4) + z ** 2
 
 
+@learn_with(SequenceLearner, sequence=range(1000))
 @learn_with(AverageLearner, rtol=1)
 def gaussian(n):
     return random.gauss(0, 1)
@@ -247,7 +252,7 @@ def test_learner_accepts_lists(learner_type, bounds):
     simple(learner, goal=lambda l: l.npoints > 10)
 
 
-@run_with(Learner1D, Learner2D, LearnerND)
+@run_with(Learner1D, Learner2D, LearnerND, SequenceLearner)
 def test_adding_existing_data_is_idempotent(learner_type, f, learner_kwargs):
     """Adding already existing data is an idempotent operation.
 
@@ -283,7 +288,7 @@ def test_adding_existing_data_is_idempotent(learner_type, f, learner_kwargs):
 
 # XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
 #      but we xfail it now, as Learner2D will be deprecated anyway
-@run_with(Learner1D, xfail(Learner2D), LearnerND, AverageLearner)
+@run_with(Learner1D, xfail(Learner2D), LearnerND, AverageLearner, SequenceLearner)
 def test_adding_non_chosen_data(learner_type, f, learner_kwargs):
     """Adding data for a point that was not returned by 'ask'."""
     # XXX: learner, control and bounds are not defined
@@ -429,7 +434,12 @@ def test_learner_performance_is_invariant_under_scaling(
 
 
 @run_with(
-    Learner1D, Learner2D, LearnerND, AverageLearner, with_all_loss_functions=False
+    Learner1D,
+    Learner2D,
+    LearnerND,
+    AverageLearner,
+    SequenceLearner,
+    with_all_loss_functions=False,
 )
 def test_balancing_learner(learner_type, f, learner_kwargs):
     """Test if the BalancingLearner works with the different types of learners."""
@@ -474,6 +484,7 @@ def test_balancing_learner(learner_type, f, learner_kwargs):
     AverageLearner,
     maybe_skip(SKOptLearner),
     IntegratorLearner,
+    SequenceLearner,
     with_all_loss_functions=False,
 )
 def test_saving(learner_type, f, learner_kwargs):
@@ -504,6 +515,7 @@ def test_saving(learner_type, f, learner_kwargs):
     AverageLearner,
     maybe_skip(SKOptLearner),
     IntegratorLearner,
+    SequenceLearner,
     with_all_loss_functions=False,
 )
 def test_saving_of_balancing_learner(learner_type, f, learner_kwargs):
@@ -541,6 +553,7 @@ def test_saving_of_balancing_learner(learner_type, f, learner_kwargs):
     AverageLearner,
     maybe_skip(SKOptLearner),
     IntegratorLearner,
+    SequenceLearner,
     with_all_loss_functions=False,
 )
 def test_saving_with_datasaver(learner_type, f, learner_kwargs):

--- a/docs/source/reference/adaptive.learner.sequence_learner.rst
+++ b/docs/source/reference/adaptive.learner.sequence_learner.rst
@@ -1,0 +1,7 @@
+adaptive.SequenceLearner
+========================
+
+.. autoclass:: adaptive.SequenceLearner
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/reference/adaptive.rst
+++ b/docs/source/reference/adaptive.rst
@@ -14,6 +14,7 @@ Learners
     adaptive.learner.learner1D
     adaptive.learner.learner2D
     adaptive.learner.learnerND
+    adaptive.learner.sequence_learner
     adaptive.learner.skopt_learner
 
 Runners

--- a/docs/source/tutorial/tutorial.SequenceLearner.rst
+++ b/docs/source/tutorial/tutorial.SequenceLearner.rst
@@ -1,0 +1,66 @@
+Tutorial `~adaptive.SequenceLearner`
+---------------------------------
+
+.. note::
+   Because this documentation consists of static html, the ``live_plot``
+   and ``live_info`` widget is not live. Download the notebook
+   in order to see the real behaviour.
+
+.. seealso::
+    The complete source code of this tutorial can be found in
+    :jupyter-download:notebook:`tutorial.SequenceLearner`
+
+.. jupyter-execute::
+    :hide-code:
+
+    import adaptive
+    adaptive.notebook_extension(_inline_js=False)
+
+    import holoviews as hv
+    import numpy as np
+
+This learner will learn a sequence. It simply returns
+the points in the provided sequence when asked.
+
+This is useful when your problem cannot be formulated in terms of
+another adaptive learner, but you still want to use Adaptive's
+routines to run, (periodically) save, and plot.
+
+.. jupyter-execute::
+
+    from adaptive import SequenceLearner
+
+    def f(x):
+        return int(x) ** 2
+
+    seq = np.linspace(-15, 15, 1000)
+    learner = SequenceLearner(f, seq)
+
+    runner = adaptive.Runner(learner, SequenceLearner.done)
+    # that goal is same as `lambda learner: learner.done()`
+
+.. jupyter-execute::
+    :hide-code:
+
+    await runner.task  # This is not needed in a notebook environment!
+
+.. jupyter-execute::
+
+    runner.live_info()
+
+.. jupyter-execute::
+
+    def plotter(learner):
+        data = learner.data if learner.data else []
+        return hv.Scatter(data)
+
+    runner.live_plot(plotter=plotter)
+
+``learner.data`` contains a dictionary that maps the index of the point of ``learner.sequence`` to the value at that point.
+
+To get the values in the same order as the input sequence (``learner.sequence``) use
+
+.. jupyter-execute::
+
+    result = learner.result()
+    print(result[:10])  # print the 10 first values

--- a/docs/source/tutorial/tutorial.rst
+++ b/docs/source/tutorial/tutorial.rst
@@ -40,6 +40,7 @@ We recommend to start with the :ref:`Tutorial `~adaptive.Learner1D``.
     tutorial.DataSaver
     tutorial.IntegratorLearner
     tutorial.LearnerND
+    tutorial.SequenceLearner
     tutorial.SKOptLearner
     tutorial.parallelism
     tutorial.advanced-topics


### PR DESCRIPTION
Adaptive has really great features to trivially parallelize and auto-save your simulation, however, sometimes you just can't formulate your problem in one of the `Learner`s. Then just for this single problem, one needs to write a lot of code to basically do what Adaptive can already do for you.

Therefore I've implemented a `SequenceLearner` that doesn't do a whole lot of fancy things, except for being a `BaseLearner` child.

With this one can easily run, `save` (and periodically save), `load`, `live_info`, and `live_plot` one's progress (if one implements a simple `plotter` function).

It's great when running simulations that might crash because if one uses periodic saving, the learner just picks up where it was before it crashed (in contrary to `ipyparallel.Client().map` where one needs to implement all those features).

@jbweston and @akhmerov, what do you guys think? If this doesn't belong in Adaptive I'll put it in another package.


Example:
```python
def f(x):
    x = int(x)
    return x ** 2

seq = range(1000)
learner = SequenceLearner(f, seq)
adaptive.runner.simple(learner, SequenceLearner.done)
# that goal is same as `lambda l: l.done()`
```

```python
def plotter(learner):
    data = learner.data if learner.data else []
    return hv.Scatter(data)

learner = SequenceLearner(f, seq)
runner = adaptive.Runner(learner, SequenceLearner.done)
runner.live_plot(plotter=plotter)
```

```python
def g(xy):
    x, y = xy
    return x ** 2 + y**2

seq = np.random.rand(1000, 2)
learner = SequenceLearner(g, seq)
runner = adaptive.Runner(learner, SequenceLearner.done)
runner.live_info()
```