### PR TITLE
Add option to display a progress bar when loading a BalancingLearner

### DIFF
--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -377,7 +377,7 @@ class BalancingLearner(BaseLearner):
             for l in self.learners:
                 l.save(fname(l), compress=compress)
 
-    def load(self, fname, compress=True):
+    def load(self, fname, compress=True, with_progress_bar=False):
         """Load the data of the child learners from pickle files
         in a directory.
 
@@ -389,16 +389,31 @@ class BalancingLearner(BaseLearner):
         compress : bool, default True
             If the data is compressed when saved, one must load it
             with compression too.
+        with_progress_bar : bool, default False
+            Display a progress bar using `tqdm`.
 
         Example
         -------
         See the example in the `BalancingLearner.save` doc-string.
         """
+        def progress(seq):
+            if not with_progress_bar:
+                return seq
+            else:
+                from adaptive.notebook_integration import in_ipynb
+                desc = "Loading learners."
+                if in_ipynb():
+                    from tqdm import tqdm_notebook
+                    return tqdm_notebook(list(seq), desc=desc)
+                else:
+                    from tqdm import tqdm
+                    return tqdm(list(seq), desc=desc)
+
         if isinstance(fname, Iterable):
-            for l, _fname in zip(self.learners, fname):
+            for l, _fname in progress(zip(self.learners, fname)):
                 l.load(_fname, compress=compress)
         else:
-            for l in self.learners:
+            for l in progress(self.learners):
                 l.load(fname(l), compress=compress)
 
     def _get_data(self):

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - ipywidgets
   - scikit-optimize
   - plotly
+  - tqdm

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ extras_require = {
         "bokeh",
         "matplotlib",
         "plotly",
+        "tqdm",
     ]
 }
 


### PR DESCRIPTION
This adds an option `with_progress_bar` to the `BalancingLearner.load` method.

Output example
![image](https://user-images.githubusercontent.com/6897215/58436730-b0612500-807b-11e9-98b4-5a2b30d9762b.png)

I am currently trying to load 370k learners which takes more than 30 min on a slow NFS. It would be really useful to display the progress.