### PR TITLE
Authors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,8 +1,13 @@
 ## Authors
-Below is a list of the contributors to Adaptive:
 
-+ [Anton Akhmerov](<https://antonakhmerov.org>)
+The current maintainers of Adaptive are:
+
 + [Bas Nijholt](<http://nijho.lt>)
++ [Joseph Weston](<https://joseph.weston.cloud>)
++ [Anton Akhmerov](<https://antonakhmerov.org>)
+
+Other contributors to Adaptive include:
+
++ Andrey E. Antipov
 + [Christoph Groth](<http://inac.cea.fr/Pisp/christoph.groth/>)
 + Jorn Hoofwijk
-+ [Joseph Weston](<https://joseph.weston.cloud>)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,3 +32,4 @@ jobs:
       MISSING_AUTHORS=$(git shortlog -s HEAD | sed -e "s/^[0-9\t ]*//"| xargs -i sh -c 'grep -q "{}" AUTHORS.md || echo "{} missing from authors"')
       if [ ! -z "$MISSING_AUTHORS" ]; then { echo $MISSING_AUTHORS; exit 1; }; fi
     displayName: 'Authors check'
+    continueOnError: true


### PR DESCRIPTION
https://github.com/python-adaptive/adaptive/pull/201 failed because of a missing author.

This PR allows the author test to fail and separates current maintainers from contributors.


`ContinueOnError: true` [is the same as WarnAndContinue](https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-ignore-errors-in-tasks?view=vs-2019#use-the-continueonerror-attribute).