### PR TITLE
WIP: raise an error when using a lambda and default executor

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -8,6 +8,7 @@ import os
 import sys
 import time
 import traceback
+import types
 import warnings
 from contextlib import suppress
 
@@ -493,6 +494,14 @@ class AsyncRunner(BaseRunner):
 
             def goal(_):
                 return False
+
+        if isinstance(learner.function, types.LambdaType) and executor is None:
+            raise ValueError(
+                "A lambda function cannot be pickled and "
+                "therefore doesn't work with the default executor."
+                "Either do not use a lamdba or use a framework that"
+                " allows this, i.e. `ipyparallel` with `dill`."
+            )
 
         super().__init__(
             learner,

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -9,7 +9,6 @@ import pickle
 import sys
 import time
 import traceback
-import types
 import warnings
 from contextlib import suppress
 
@@ -497,17 +496,16 @@ class AsyncRunner(BaseRunner):
                 return False
 
         if executor is None:
-            if isinstance(learner.function, types.LambdaType):
-                raise ValueError(
-                    "A lambda function cannot be pickled and "
-                    "therefore doesn't work with the default executor."
-                    "Either do not use a lamdba or use a framework that"
-                    " allows this, e.g. `ipyparallel` with `dill`."
-                )
             try:
                 pickle.dumps(learner.function)
             except pickle.PicklingError:
-                raise ValueError("`learner.function` needs to be pickleble.")
+                raise ValueError(
+                    "`learner.function` cannot be pickled (is it a lamdba function?)"
+                    " and therefore does not work with the default executor."
+                    " Either make sure the function is pickleble or use an executor"
+                    " that might work with 'hard to pickle'-functions"
+                    " , e.g. `ipyparallel` with `dill`."
+                )
 
         super().__init__(
             learner,

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -495,7 +495,7 @@ class AsyncRunner(BaseRunner):
             def goal(_):
                 return False
 
-        if executor is None:
+        if executor is None and not inspect.iscoroutinefunction(learner.function):
             try:
                 pickle.dumps(learner.function)
             except pickle.PicklingError:


### PR DESCRIPTION
Closes #206.

It is not obvious that this blocks the kernel, but it does hang forever and does not error.

```python
import adaptive
adaptive.notebook_extension()

f = lambda xy: xy[0]**2 + xy[1]**2
learner = adaptive.Learner2D(f, bounds=[(-1, 1), (-1, 1)])
runner = adaptive.Runner(learner, goal=lambda l: l.npoints >= 1000)
```

This PR makes sure an error is raised, however, might this be caused by an underlying issue?