### PR TITLE
2D: add triangle_loss

### DIFF
--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy import interpolate
 
 from adaptive.learner.base_learner import BaseLearner
+from adaptive.learner.triangulation import simplex_volume_in_embedding
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.utils import cache_latest
 
@@ -210,6 +211,45 @@ def choose_point_in_triangle(triangle, max_badness):
     else:
         point = triangle.mean(axis=0)
     return point
+
+
+def triangle_loss(ip):
+    r"""Computes the average of the volumes of the simplex combined with each
+    neighbouring point.
+
+    Parameters
+    ----------
+    ip : `scipy.interpolate.LinearNDInterpolator` instance
+
+    Returns
+    -------
+    triangle_loss : list
+        The mean volume per triangle.
+
+    Notes
+    -----
+    This loss function is *extremely* slow. It is here because it gives the
+    same result as the `adaptive.LearnerND`\s
+    `~adaptive.learner.learnerND.triangle_loss`.
+    """
+    tri = ip.tri
+
+    def get_neighbors(i, ip):
+        n = np.array([tri.simplices[n] for n in tri.neighbors[i] if n != -1])
+        # remove the vertices that are in the simplex
+        c = np.setdiff1d(n.reshape(-1), tri.simplices[i])
+        return np.concatenate((tri.points[c], ip.values[c]), axis=-1)
+
+    simplices = np.concatenate(
+        [tri.points[tri.simplices], ip.values[tri.simplices]], axis=-1
+    )
+    neighbors = [get_neighbors(i, ip) for i in range(len(tri.simplices))]
+
+    return [
+        sum(simplex_volume_in_embedding(np.vstack([simplex, n])) for n in neighbors[i])
+        / len(neighbors[i])
+        for i, simplex in enumerate(simplices)
+    ]
 
 
 class Learner2D(BaseLearner):


### PR DESCRIPTION
For symmetry reasons, I add `triangle_loss` which works with the `Learner2D`.

Currently, it is very slow, for a learner with 1000 points:
```python
ip = learner.ip()
%timeit adaptive.learner.learner2D.triangle_loss(ip)
%timeit adaptive.learner.learner2D.default_loss(ip)
```
```
652 ms ± 154 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
1.92 ms ± 96.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Result:
![image](https://user-images.githubusercontent.com/6897215/66477233-e1288080-ea97-11e9-948b-a89e8f6a4de6.png)
