### PR TITLE
Power up pre-commit

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = PIL,atomicwrites,holoviews,ipykernel,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers,zmq

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,43 @@
 repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-docstring-first
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: check-ast
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    -   id: flake8
+        args:
+          - --max-line-length=500
+          - --ignore=E203,E266,E501,W503
+          - --max-complexity=18
+          - --select=B,C,E,F,W,T4,B9
 -   repo: https://github.com/ambv/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
     - id: black
       language_version: python3.7
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v1.25.2
     hooks:
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.8
+    -   id: pyupgrade
+        args: ['--py36-plus']
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
     hooks:
-    -   id: flake8
-        args: ['--max-line-length=500', '--ignore=E203,E266,E501,W503', '--max-complexity=18', '--select=B,C,E,F,W,T4,B9']
+    -   id: isort
+        args:
+          - --multi-line=3
+          - --trailing-comma
+          - --force-grid-wrap=0
+          - --use-parentheses
+          - --line-width=88
+-   repo: https://github.com/asottile/seed-isort-config
+    rev: v1.9.3
+    hooks:
+    -   id: seed-isort-config

--- a/adaptive/__init__.py
+++ b/adaptive/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from contextlib import suppress
 
 from adaptive import learner, runner, utils

--- a/adaptive/_version.py
+++ b/adaptive/_version.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This file is part of 'miniver': https://github.com/jbweston/miniver
 #
 import os

--- a/adaptive/learner/__init__.py
+++ b/adaptive/learner/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from contextlib import suppress
 
 from adaptive.learner.average_learner import AverageLearner

--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from math import sqrt
 
 import numpy as np

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import itertools
 from collections import defaultdict
 from collections.abc import Iterable

--- a/adaptive/learner/base_learner.py
+++ b/adaptive/learner/base_learner.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
-
 import abc
 from contextlib import suppress
 from copy import deepcopy
 
-from adaptive.utils import load, save, _RequireAttrsABCMeta
+from adaptive.utils import _RequireAttrsABCMeta, load, save
 
 
 def uses_nth_neighbors(n):

--- a/adaptive/learner/data_saver.py
+++ b/adaptive/learner/data_saver.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import functools
 from collections import OrderedDict
 

--- a/adaptive/learner/integrator_coeffs.py
+++ b/adaptive/learner/integrator_coeffs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Based on an adaptive quadrature algorithm by Pedro Gonnet
 
 from collections import defaultdict

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Based on an adaptive quadrature algorithm by Pedro Gonnet
 
 import sys
@@ -572,9 +571,15 @@ class IntegratorLearner(BaseLearner):
         )
 
     def _set_data(self, data):
-        self.priority_split, self.data, self.pending_points, self._stack, x_mapping, self.ivals, self.first_ival = (
-            data
-        )
+        (
+            self.priority_split,
+            self.data,
+            self.pending_points,
+            self._stack,
+            x_mapping,
+            self.ivals,
+            self.first_ival,
+        ) = data
 
         # Add the pending_points to the _stack such that they are evaluated again
         for x in self.pending_points:

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import itertools
 import math
 from collections.abc import Iterable

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import itertools
 import warnings
 from collections import OrderedDict

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import functools
 import itertools
 import random
@@ -340,8 +338,8 @@ class LearnerND(BaseLearner):
         self._min_value = None
         self._max_value = None
         self._output_multiplier = (
-            1
-        )  # If we do not know anything, do not scale the values
+            1  # If we do not know anything, do not scale the values
+        )
         self._recompute_losses_factor = 1.1
 
         # create a private random number generator with fixed seed

--- a/adaptive/learner/skopt_learner.py
+++ b/adaptive/learner/skopt_learner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import collections
 
 import numpy as np

--- a/adaptive/learner/triangulation.py
+++ b/adaptive/learner/triangulation.py
@@ -228,7 +228,7 @@ def simplex_volume_in_embedding(vertices) -> float:
     # Make matrix and find volume
     sq_dists_mat = scipy.spatial.distance.squareform(bordered)
 
-    coeff = -(-2) ** (num_verts - 1) * factorial(num_verts - 1) ** 2
+    coeff = -((-2) ** (num_verts - 1)) * factorial(num_verts - 1) ** 2
     vol_square = fast_det(sq_dists_mat) / coeff
 
     if vol_square < 0:

--- a/adaptive/notebook_integration.py
+++ b/adaptive/notebook_integration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import asyncio
 import datetime
 import importlib

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import abc
 import asyncio
 import concurrent.futures as concurrent

--- a/adaptive/tests/test_average_learner.py
+++ b/adaptive/tests/test_average_learner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import random
 
 import numpy as np

--- a/adaptive/tests/test_balancing_learner.py
+++ b/adaptive/tests/test_balancing_learner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from adaptive.learner import BalancingLearner, Learner1D

--- a/adaptive/tests/test_cquad.py
+++ b/adaptive/tests/test_cquad.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from functools import partial
 from operator import attrgetter
 

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import random
 
 import numpy as np

--- a/adaptive/tests/test_learnernd.py
+++ b/adaptive/tests/test_learnernd.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import scipy.spatial
 

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import collections
 import functools as ft
 import inspect
@@ -129,7 +127,7 @@ def linear_with_peak(x, d: uniform(-1, 1)):
 def ring_of_fire(xy, d: uniform(0.2, 1)):
     a = 0.2
     x, y = xy
-    return x + math.exp(-(x ** 2 + y ** 2 - d ** 2) ** 2 / a ** 4)
+    return x + math.exp(-((x ** 2 + y ** 2 - d ** 2) ** 2) / a ** 4)
 
 
 @learn_with(LearnerND, bounds=((-1, 1), (-1, 1), (-1, 1)))
@@ -137,7 +135,7 @@ def ring_of_fire(xy, d: uniform(0.2, 1)):
 def sphere_of_fire(xyz, d: uniform(0.2, 1)):
     a = 0.2
     x, y, z = xyz
-    return x + math.exp(-(x ** 2 + y ** 2 + z ** 2 - d ** 2) ** 2 / a ** 4) + z ** 2
+    return x + math.exp(-((x ** 2 + y ** 2 + z ** 2 - d ** 2) ** 2) / a ** 4) + z ** 2
 
 
 @learn_with(SequenceLearner, sequence=range(1000))

--- a/adaptive/tests/test_notebook_integration.py
+++ b/adaptive/tests/test_notebook_integration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import ipykernel.iostream
 import zmq
 

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import asyncio
 import time
 

--- a/adaptive/tests/test_skopt_learner.py
+++ b/adaptive/tests/test_skopt_learner.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pytest
 

--- a/adaptive/tests/test_triangulation.py
+++ b/adaptive/tests/test_triangulation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import itertools
 from collections import Counter
 from math import factorial

--- a/adaptive/tests/unit/test_learnernd.py
+++ b/adaptive/tests/unit/test_learnernd.py
@@ -12,7 +12,7 @@ def ring_of_fire(xy):
     a = 0.2
     d = 0.7
     x, y = xy
-    return x + math.exp(-(x ** 2 + y ** 2 - d ** 2) ** 2 / a ** 4)
+    return x + math.exp(-((x ** 2 + y ** 2 - d ** 2) ** 2) / a ** 4)
 
 
 def test_learnerND_inits_loss_depends_on_neighbors_correctly():

--- a/adaptive/tests/unit/test_learnernd_integration.py
+++ b/adaptive/tests/unit/test_learnernd_integration.py
@@ -11,7 +11,7 @@ from adaptive.runner import simple as SimpleRunner
 def ring_of_fire(xy, d=0.75):
     a = 0.2
     x, y = xy
-    return x + math.exp(-(x ** 2 + y ** 2 - d ** 2) ** 2 / a ** 4)
+    return x + math.exp(-((x ** 2 + y ** 2 - d ** 2) ** 2) / a ** 4)
 
 
 def test_learnerND_runs_to_10_points():

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import abc
 import functools
 import gzip

--- a/benchmarks/benchmarks/benchmarks.py
+++ b/benchmarks/benchmarks/benchmarks.py
@@ -15,7 +15,7 @@ def f_1d(x, offset=offset):
 def f_2d(xy):
     x, y = xy
     a = 0.2
-    return x + np.exp(-(x ** 2 + y ** 2 - 0.75 ** 2) ** 2 / a ** 4)
+    return x + np.exp(-((x ** 2 + y ** 2 - 0.75 ** 2) ** 2) / a ** 4)
 
 
 class TimeLearner1D:

--- a/docs/logo.py
+++ b/docs/logo.py
@@ -8,7 +8,7 @@ from PIL import Image, ImageDraw
 
 sys.path.insert(0, os.path.abspath(".."))  # to get adaptive on the path
 
-import adaptive  # noqa: E402
+import adaptive  # noqa: E402, isort:skip
 
 holoviews.notebook_extension("matplotlib")
 
@@ -19,7 +19,7 @@ def create_and_run_learner():
 
         x, y = xy
         a = 0.2
-        return x + np.exp(-(x ** 2 + y ** 2 - 0.75 ** 2) ** 2 / a ** 4)
+        return x + np.exp(-((x ** 2 + y ** 2 - 0.75 ** 2) ** 2) / a ** 4)
 
     learner = adaptive.Learner2D(ring, bounds=[(-1, 1), (-1, 1)])
     adaptive.runner.simple(learner, goal=lambda l: l.loss() < 0.01)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #
@@ -18,11 +17,10 @@ import sys
 package_path = os.path.abspath("../..")
 # Insert into sys.path so that we can import adaptive here
 sys.path.insert(0, package_path)
-
-import adaptive  # noqa: E402
-
 # Insert into PYTHONPATH so that jupyter-sphinx will pick it up
 os.environ["PYTHONPATH"] = ":".join((package_path, os.environ.get("PYTHONPATH", "")))
+
+import adaptive  # noqa: E402, isort:skip
 
 # -- Project information -----------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import sys
 


### PR DESCRIPTION
This adds some whitespace checks, `isort`, `pyupgrade`, and some other code checks from the `pre-commit-hooks` repo.

Note that `pyupgrade` doesn't really change much here because I used this already before.

A summary of what the hooks do:
* `pyupgrade` - A tool (and pre-commit hook) to automatically upgrade syntax for newer versions of the language.
* `end-of-file-fixer` - Makes sure files end in a newline and only a newline.
* `check-docstring-first` - Checks for a common error of placing code before the docstring.
* `check-yaml` - Attempts to load all yaml files to verify syntax.
* `debug-statements` - Check for debugger imports and py37+ breakpoint() calls in python source.
* `check-ast` - Simply check whether files parse as valid python.
* `seed-isort-config` - Statically populate the `known_third_party` `isort` setting because `isort` sucks at figuring out which third party libs are used. (from author of `pre-commit`)

I have also added this summary to the first commit.