### PR TITLE
add a Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Description
+
+Please include a summary of the change and which (if so) issue is fixed.
+
+Fixes #(ISSUE_NUMBER_HERE)
+
+## Checklist
+
+- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
+- [ ] `pytest` passed
+
+## Type of change
+
+*Check relevant option(s).*
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update


### PR DESCRIPTION
Now it should be more clear that one should run `pre-commit`.
People probably don't read https://adaptive.readthedocs.io/en/latest/docs.html#development before contributing.

@jbweston and @akhmerov, what do you think?