### PR TITLE
improve the style of the live_info widget, closes #250

### DIFF
--- a/adaptive/notebook_integration.py
+++ b/adaptive/notebook_integration.py
@@ -228,14 +228,16 @@ def live_info(runner, *, update_interval=0.5):
 
     runner.ioloop.create_task(update())
 
-    display(
-        ipywidgets.HBox(
-            (status, cancel),
-            layout=ipywidgets.Layout(
-                border="solid 1px", width="200px", align_items="center"
-            ),
-        )
-    )
+    display(ipywidgets.VBox((status, cancel)))
+
+
+def _table_row(i, key, value):
+    """Style the rows of a table. Based on the default Jupyterlab table style."""
+    style_odd = "text-align: right; padding: 0.5em 0.5em; line-height: 1.0;"
+    style_even = style_odd + "background: var(--md-grey-100);"
+    template = '<tr><th style="{style}">{key}</th><th style="{style}">{value}</th></tr>'
+    style = style_odd if i % 2 == 1 else style_even
+    return template.format(style=style, key=key, value=value)
 
 
 def _info_html(runner):
@@ -260,11 +262,10 @@ def _info_html(runner):
     with suppress(Exception):
         info.append(("latest loss", f'{runner.learner._cache["loss"]:.3f}'))
 
-    template = '<dt class="ignore-css">{}</dt><dd>{}</dd>'
-    table = "\n".join(template.format(k, v) for k, v in info)
+    table = "\n".join(_table_row(i, k, v) for i, (k, v) in enumerate(info))
 
     return f"""
-        <dl>
+        <table>
         {table}
-        </dl>
+        </table>
     """


### PR DESCRIPTION

## Description
Based on the default style of the Jupyterlab table.

In Jupyterlab:
![image](https://user-images.githubusercontent.com/6897215/71104078-86a85080-21bb-11ea-8edf-5bd02abc2d38.png)

In the notebook:
![image](https://user-images.githubusercontent.com/6897215/71104118-958f0300-21bb-11ea-95a0-3af81b312fe7.png)


Fixes #250

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
