### PR TITLE
color the overhead between red and green

### DIFF
--- a/adaptive/notebook_integration.py
+++ b/adaptive/notebook_integration.py
@@ -250,10 +250,14 @@ def _info_html(runner):
         "finished": "green",
     }[status]
 
+    overhead = runner.overhead()
+    red_level = max(0, min(int(255 * overhead / 100), 255))
+    overhead_color = "#{:02x}{:02x}{:02x}".format(red_level, 255 - red_level, 0)
+
     info = [
         ("status", f'<font color="{color}">{status}</font>'),
         ("elapsed time", datetime.timedelta(seconds=runner.elapsed_time())),
-        ("overhead", f"{runner.overhead():.2f}%"),
+        ("overhead", f'<font color="{overhead_color}">{overhead:.2f}%</font>'),
     ]
 
     with suppress(Exception):


### PR DESCRIPTION
## Description

The color of the reported overhead will change to red if it's bad and to green if it's good.


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/6897215/71106163-1bf91400-21bf-11ea-894d-0a5ef3b897c6.gif)


## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

