### PR TITLE
disable test of runner using distributed

### DIFF
--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -120,7 +120,7 @@ def test_ipyparallel_executor(ipyparallel_executor):
 @flaky.flaky(max_runs=5)
 @pytest.mark.timeout(60)
 @pytest.mark.skipif(not with_distributed, reason="dask.distributed is not installed")
-@pytest.mark.skipif(sys.version_info[:2] == (3, 8), reason="XXX: seems to always fail")
+@pytest.mark.skipif(os.name == "nt", reason="XXX: seems to always fail")
 def test_distributed_executor():
     from distributed import Client
 


### PR DESCRIPTION
## Description

It seems to fail a lot on Windows, making the whole pipeline fail.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
