### PR TITLE
add support for complex numbers in Learner1D

### DIFF
--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -386,8 +386,11 @@ class Learner1D(BaseLearner):
             )
 
         # either it is a float/int, if not, try casting to a np.array
-        if not isinstance(y, (float, int)):
-            y = np.asarray(y, dtype=float)
+        if not isinstance(y, (float, int, complex)):
+            if np.iscomplexobj(y):
+                y = np.asarray(y, dtype=complex)
+            else:
+                y = np.asarray(y, dtype=float)
 
         # Add point to the real data dict
         self.data[x] = y


### PR DESCRIPTION
## Description
I ran into an issue interpolating scattering matrices using adaptive where Learner1D.tell casts complex data to real. The reasoning for this is not immediately apparent so I made a small change that seems to work fine in this case. This is by no means a complete implementation but it seems to function fine with the loss function.

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
