### PR TITLE
MNT: add vscode config directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ ENV/
 benchmarks/html/
 benchmarks/results/
 .asv
+
+# vscode configuration
+.vscode/


### PR DESCRIPTION
## Description

Add .vscode to gitignore to avoid tracking editor config.