### PR TITLE
fix docs build and pin pyviz_comms=0.7.2

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - ipywidgets=7.4.2
   - jupyter_sphinx=0.2.2
   - atomicwrites=1.3.0
+  - pyviz_comms=0.7.2
   - pip:
     - sphinx_fontawesome==0.0.6
     - m2r==0.2.1


### PR DESCRIPTION
HoloViews didn't have a strict pinning for it.
In the new version https://github.com/holoviz/pyviz_comms/blob/v0.7.2/pyviz_comms/__init__.py#L102
was removed, while holoviews=1.11.3 seems to depend on it.

## Description

Please include a summary of the change and which (if so) issue is fixed.

Fixes #(ISSUE_NUMBER_HERE)

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
