### PR TITLE
add support for loky

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -32,6 +32,13 @@ try:
 except ModuleNotFoundError:
     with_mpi4py = False
 
+try:
+    import loky
+
+    with_loky = True
+except ModuleNotFoundError:
+    with_loky = False
+
 with suppress(ModuleNotFoundError):
     import uvloop
 
@@ -764,6 +771,8 @@ def _get_ncores(ex):
     elif isinstance(
         ex, (concurrent.ProcessPoolExecutor, concurrent.ThreadPoolExecutor)
     ):
+        return ex._max_workers  # not public API!
+    elif with_loky and isinstance(ex, loky.reusable_executor._ReusablePoolExecutor):
         return ex._max_workers  # not public API!
     elif isinstance(ex, SequentialExecutor):
         return 1

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -276,7 +276,8 @@ class BlockingRunner(BaseRunner):
         the learner as its sole argument, and return True when we should
         stop requesting more points.
     executor : `concurrent.futures.Executor`, `distributed.Client`,\
-               `mpi4py.futures.MPIPoolExecutor`, or `ipyparallel.Client`, optional
+               `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
+               `loky.get_reusable_executor`, optional
         The executor in which to evaluate the function to be learned.
         If not provided, a new `~concurrent.futures.ProcessPoolExecutor`.
     ntasks : int, optional
@@ -393,7 +394,8 @@ class AsyncRunner(BaseRunner):
         stop requesting more points. If not provided, the runner will run
         forever, or until ``self.task.cancel()`` is called.
     executor : `concurrent.futures.Executor`, `distributed.Client`,\
-               `mpi4py.futures.MPIPoolExecutor`, or `ipyparallel.Client`, optional
+               `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
+               `loky.get_reusable_executor`, optional
         The executor in which to evaluate the function to be learned.
         If not provided, a new `~concurrent.futures.ProcessPoolExecutor`.
     ntasks : int, optional

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -12,9 +12,13 @@ from contextlib import suppress
 from adaptive.notebook_integration import in_ipynb, live_info, live_plot
 
 try:
-    import ipyparallel
+    if sys.version_info < (3, 8):
+        # XXX: remove when ipyparallel 6.2.5 is released
+        import ipyparallel
 
-    with_ipyparallel = True
+        with_ipyparallel = True
+    else:
+        with_ipyparallel = False
 except ModuleNotFoundError:
     with_ipyparallel = False
 

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -243,10 +243,13 @@ class BaseRunner(metaclass=abc.ABCMeta):
 
     def _cleanup(self):
         if self.shutdown_executor:
-            # XXX: temporary set wait=True for Python 3.7
+            # XXX: temporary set wait=True because of a bug with Python ≥3.7
+            # and loky in any Python version.
             # see https://github.com/python-adaptive/adaptive/issues/156
             # and https://github.com/python-adaptive/adaptive/pull/164
-            self.executor.shutdown(wait=True if sys.version_info >= (3, 7) else False)
+            # and https://bugs.python.org/issue36281
+            # and https://github.com/joblib/loky/issues/241
+            self.executor.shutdown(wait=True)
         self.end_time = time.time()
 
     @property

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -749,9 +749,16 @@ class SequentialExecutor(concurrent.Executor):
         pass
 
 
+def _default_executor():
+    if with_loky:
+        return loky.get_reusable_executor()
+    else:
+        return concurrent.ProcessPoolExecutor()
+
+
 def _ensure_executor(executor):
     if executor is None:
-        executor = concurrent.ProcessPoolExecutor()
+        executor = _default_executor()
 
     if isinstance(executor, concurrent.Executor):
         return executor

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -146,6 +146,6 @@ def test_distributed_executor():
 
 @pytest.mark.skipif(not with_loky, reason="loky not installed")
 def test_loky_executor(loky_executor):
-    learner = Learner1D(linear, (-1, 1))
+    learner = Learner1D(lambda x: x, (-1, 1))
     BlockingRunner(learner, trivial_goal, executor=loky_executor)
     assert learner.npoints > 0

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -15,6 +15,7 @@ from adaptive.runner import (
     stop_after,
     with_distributed,
     with_ipyparallel,
+    with_loky,
 )
 
 
@@ -91,6 +92,13 @@ def ipyparallel_executor():
         raise RuntimeError("Could not stop ipcluster")
 
 
+@pytest.fixture(scope="session")
+def loky_executor():
+    import loky
+
+    return loky.get_reusable_executor()
+
+
 def linear(x):
     return x
 
@@ -133,4 +141,11 @@ def test_distributed_executor():
     client = Client(n_workers=1)
     BlockingRunner(learner, trivial_goal, executor=client)
     client.shutdown()
+    assert learner.npoints > 0
+
+
+@pytest.mark.skipif(not with_loky, reason="loky not installed")
+def test_loky_executor(loky_executor):
+    learner = Learner1D(linear, (-1, 1))
+    BlockingRunner(learner, trivial_goal, executor=loky_executor)
     assert learner.npoints > 0

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -147,5 +147,7 @@ def test_distributed_executor():
 @pytest.mark.skipif(not with_loky, reason="loky not installed")
 def test_loky_executor(loky_executor):
     learner = Learner1D(lambda x: x, (-1, 1))
-    BlockingRunner(learner, trivial_goal, executor=loky_executor)
+    BlockingRunner(
+        learner, trivial_goal, executor=loky_executor, shutdown_executor=True
+    )
     assert learner.npoints > 0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -139,6 +139,7 @@ intersphinx_mapping = {
     "holoviews": ("https://holoviews.org/", None),
     "ipyparallel": ("https://ipyparallel.readthedocs.io/en/stable/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "loky": ("https://loky.readthedocs.io/en/stable/", None),
 }
 
 

--- a/docs/source/tutorial/tutorial.parallelism.rst
+++ b/docs/source/tutorial/tutorial.parallelism.rst
@@ -120,9 +120,9 @@ How you call MPI might depend on your specific queuing system, with SLURM for ex
 `loky.get_reusable_executor`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This executor is basically a powered up version of `~concurrent.futures.ProcessPoolExecutor`, check its `documentation <https://loky.readthedocs.io/>`_.
-Among other things, it allows one to reuse the executor and uses ``cloudpickle`` on the background.
-This means you can even run closures, lambdas, or other functions that are not picklable with `pickle`.
+This executor is basically a powered-up version of `~concurrent.futures.ProcessPoolExecutor`, check its `documentation <https://loky.readthedocs.io/>`_.
+Among other things, it allows to *reuse* the executor and uses ``cloudpickle`` for serialization.
+This means you can even learn closures, lambdas, or other functions that are not picklable with `pickle`.
 
 .. code:: python
 

--- a/docs/source/tutorial/tutorial.parallelism.rst
+++ b/docs/source/tutorial/tutorial.parallelism.rst
@@ -116,3 +116,21 @@ How you call MPI might depend on your specific queuing system, with SLURM for ex
     #SBATCH --ntasks 100
 
     srun -n $SLURM_NTASKS --mpi=pmi2 ~/miniconda3/envs/py37_min/bin/python -m mpi4py.futures run_learner.py
+
+`loky.get_reusable_executor`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This executor is basically a powered up version of `~concurrent.futures.ProcessPoolExecutor`, check its `documentation <https://loky.readthedocs.io/>`_.
+Among other things, it allows one to reuse the executor and uses ``cloudpickle`` on the background.
+This means you can even run closures, lambdas, or other functions that are not picklable with `pickle`.
+
+.. code:: python
+
+    from loky import get_reusable_executor
+    ex = get_reusable_executor()
+
+    f = lambda x: x
+    learner = adaptive.Learner1D(f, bounds=(-1, 1))
+
+    runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01, executor=ex)
+    runner.live_info()

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - ipyparallel
   - distributed
   - ipykernel>=4.8*
+  - loky
   - jupyter_client>=5.2.2
   - ipywidgets
   - scikit-optimize

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ extras_require = {
     "other": [
         "ipyparallel",
         "distributed",
+        "loky",
         "scikit-optimize",
         "wexpect" if os.name == "nt" else "pexpect",
     ],


### PR DESCRIPTION
## Description

This adds support for `loky` which has a `ProcessPoolExecutor` that can for example use `cloudpickle`.

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
