### PR TITLE
make learners picklable

### DIFF
--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -144,3 +144,16 @@ class AverageLearner(BaseLearner):
 
     def _set_data(self, data):
         self.data, self.npoints, self.sum_f, self.sum_f_sq = data
+
+    def __getstate__(self):
+        return (
+            self.function,
+            self.atol,
+            self.rtol,
+            self._get_data(),
+        )
+
+    def __setstate__(self, state):
+        function, atol, rtol, data = state
+        self.__init__(function, atol, rtol)
+        self._set_data(data)

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -446,10 +446,8 @@ class BalancingLearner(BaseLearner):
             self.learners,
             self._cdims_default,
             self.strategy,
-            self._get_data(),
         )
 
     def __setstate__(self, state):
-        learners, cdims, strategy, data = state
+        learners, cdims, strategy = state
         self.__init__(learners, cdims=cdims, strategy=strategy)
-        self._set_data(data)

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -440,3 +440,16 @@ class BalancingLearner(BaseLearner):
     def _set_data(self, data):
         for l, _data in zip(self.learners, data):
             l._set_data(_data)
+
+    def __getstate__(self):
+        return (
+            self.learners,
+            self._cdims_default,
+            self.strategy,
+            self._get_data(),
+        )
+
+    def __setstate__(self, state):
+        learners, cdims, strategy, data = state
+        self.__init__(learners, cdims=cdims, strategy=strategy)
+        self._set_data(data)

--- a/adaptive/learner/data_saver.py
+++ b/adaptive/learner/data_saver.py
@@ -51,6 +51,18 @@ class DataSaver:
         learner_data, self.extra_data = data
         self.learner._set_data(learner_data)
 
+    def __getstate__(self):
+        return (
+            self.learner,
+            self.arg_picker,
+            self._get_data(),
+        )
+
+    def __setstate__(self, state):
+        learner, arg_picker, data = state
+        self.__init__(learner, arg_picker)
+        self._set_data(data)
+
     @copy_docstring_from(BaseLearner.save)
     def save(self, fname, compress=True):
         # We copy this method because the 'DataSaver' is not a

--- a/adaptive/learner/data_saver.py
+++ b/adaptive/learner/data_saver.py
@@ -55,13 +55,13 @@ class DataSaver:
         return (
             self.learner,
             self.arg_picker,
-            self._get_data(),
+            self.extra_data,
         )
 
     def __setstate__(self, state):
-        learner, arg_picker, data = state
+        learner, arg_picker, extra_data = state
         self.__init__(learner, arg_picker)
-        self._set_data(data)
+        self.extra_data = extra_data
 
     @copy_docstring_from(BaseLearner.save)
     def save(self, fname, compress=True):

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -591,3 +591,16 @@ class IntegratorLearner(BaseLearner):
         self.x_mapping = defaultdict(lambda: SortedSet([], key=attrgetter("rdepth")))
         for k, _set in x_mapping.items():
             self.x_mapping[k].update(_set)
+
+    def __getstate__(self):
+        return (
+            self.function,
+            self.bounds,
+            self.tol,
+            self._get_data(),
+        )
+
+    def __setstate__(self, state):
+        function, bounds, tol, data = state
+        self.__init__(function, bounds, tol)
+        self._set_data(data)

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -625,6 +625,19 @@ class Learner1D(BaseLearner):
         if data:
             self.tell_many(*zip(*data.items()))
 
+    def __getstate__(self):
+        return (
+            self.function,
+            self.bounds,
+            self.loss_per_interval,
+            self._get_data(),
+        )
+
+    def __setstate__(self, state):
+        function, bounds, loss_per_interval, data = state
+        self.__init__(function, bounds, loss_per_interval)
+        self._set_data(data)
+
 
 def loss_manager(x_scale):
     def sort_key(ival, loss):

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -630,13 +630,17 @@ class Learner1D(BaseLearner):
             self.function,
             self.bounds,
             self.loss_per_interval,
+            dict(self.losses),  # SortedDict cannot be pickled
+            dict(self.losses_combined),  # ItemSortedDict cannot be pickled
             self._get_data(),
         )
 
     def __setstate__(self, state):
-        function, bounds, loss_per_interval, data = state
+        function, bounds, loss_per_interval, losses, losses_combined, data = state
         self.__init__(function, bounds, loss_per_interval)
         self._set_data(data)
+        self.losses.update(losses)
+        self.losses_combined.update(losses_combined)
 
 
 def loss_manager(x_scale):

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -706,3 +706,16 @@ class Learner2D(BaseLearner):
         for point in copy(self._stack):
             if point in self.data:
                 self._stack.pop(point)
+
+    def __getstate__(self):
+        return (
+            self.function,
+            self.bounds,
+            self.loss_per_triangle,
+            self._get_data(),
+        )
+
+    def __setstate__(self, state):
+        function, bounds, loss_per_triangle, data = state
+        self.__init__(function, bounds, loss_per_triangle)
+        self._set_data(data)

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -712,10 +712,12 @@ class Learner2D(BaseLearner):
             self.function,
             self.bounds,
             self.loss_per_triangle,
+            self._stack,
             self._get_data(),
         )
 
     def __setstate__(self, state):
-        function, bounds, loss_per_triangle, data = state
+        function, bounds, loss_per_triangle, _stack, data = state
         self.__init__(function, bounds, loss_per_triangle)
         self._set_data(data)
+        self._stack = _stack

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -83,16 +83,6 @@ class SequenceLearner(BaseLearner):
 
         return points, loss_improvements
 
-    def _get_data(self):
-        return self.data
-
-    def _set_data(self, data):
-        if data:
-            indices, values = zip(*data.items())
-            # the points aren't used by tell, so we can safely pass None
-            points = [(i, None) for i in indices]
-            self.tell_many(points, values)
-
     def loss(self, real=True):
         if not (self._to_do_indices or self.pending_points):
             return 0
@@ -128,3 +118,25 @@ class SequenceLearner(BaseLearner):
     @property
     def npoints(self):
         return len(self.data)
+
+    def _get_data(self):
+        return self.data
+
+    def _set_data(self, data):
+        if data:
+            indices, values = zip(*data.items())
+            # the points aren't used by tell, so we can safely pass None
+            points = [(i, None) for i in indices]
+            self.tell_many(points, values)
+
+    def __getstate__(self):
+        return (
+            self._original_function,
+            self.sequence,
+            self._get_data(),
+        )
+
+    def __setstate__(self, state):
+        function, sequence, data = state
+        self.__init__(function, sequence)
+        self._set_data(data)

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -85,6 +85,8 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
         f = f_for_pickle  # noqa: F811
 
     learner = learner_type(f, **learner_kwargs)
+    if learner_type is Learner1D:
+        learner._recompute_losses_factor = 1
 
     simple(learner, goal_1)
     learner_bytes = serializer.dumps(learner)

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -86,6 +86,8 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
 
     simple(learner, goal_1)
     learner_bytes = serializer.dumps(learner)
+    loss = learner.loss()
+    asked = learner.ask(1)
 
     if serializer is not pickle:
         # With pickle the functions are only pickled by reference
@@ -94,6 +96,15 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
 
     learner_loaded = serializer.loads(learner_bytes)
     assert learner_loaded.npoints >= 10
+    assert loss == learner_loaded.loss()
+
+    if learner_type is not Learner2D:
+        # cannot test this for Learner2D because
+        # xfailing test_point_adding_order_is_irrelevant
+        assert asked == learner_loaded.ask(1)
+        # load again to undo the ask
+        learner_loaded = serializer.loads(learner_bytes)
+
     simple(learner_loaded, goal_2)
     assert learner_loaded.npoints >= 20
 

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -2,6 +2,7 @@ import operator
 import pickle
 import random
 
+import flaky
 import pytest
 
 from adaptive.learner import (
@@ -69,6 +70,7 @@ def f_for_pickle_datasaver(x):
     return dict(x=x, y=x)
 
 
+@flaky.flaky(max_runs=3)
 @pytest.mark.parametrize(
     "learner_type, learner_kwargs, serializer", learners,
 )

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -87,7 +87,8 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
     simple(learner, goal_1)
     learner_bytes = serializer.dumps(learner)
     loss = learner.loss()
-    asked = learner.ask(1)
+    asked = learner.ask(10)
+    data = learner.data
 
     if serializer is not pickle:
         # With pickle the functions are only pickled by reference
@@ -97,8 +98,10 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
     learner_loaded = serializer.loads(learner_bytes)
     assert learner_loaded.npoints == 10
     assert loss == learner_loaded.loss()
+    assert data == learner_loaded.data
 
-    assert asked == learner_loaded.ask(1)
+    assert asked == learner_loaded.ask(10)
+
     # load again to undo the ask
     learner_loaded = serializer.loads(learner_bytes)
 

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -1,0 +1,103 @@
+import random
+
+import cloudpickle
+import pytest
+
+from adaptive.learner import (
+    AverageLearner,
+    BalancingLearner,
+    DataSaver,
+    IntegratorLearner,
+    Learner1D,
+    Learner2D,
+    LearnerND,
+    SequenceLearner,
+)
+from adaptive.runner import simple
+
+
+def goal_1(learner):
+    return learner.npoints >= 10
+
+
+def goal_2(learner):
+    return learner.npoints >= 20
+
+
+@pytest.mark.parametrize(
+    "learner_type, learner_kwargs",
+    [
+        (Learner1D, dict(bounds=(-1, 1))),
+        (Learner2D, dict(bounds=[(-1, 1), (-1, 1)])),
+        (LearnerND, dict(bounds=[(-1, 1), (-1, 1), (-1, 1)])),
+        (SequenceLearner, dict(sequence=list(range(100)))),
+        (IntegratorLearner, dict(bounds=(0, 1), tol=1e-3)),
+        (AverageLearner, dict(atol=0.1)),
+    ],
+)
+def test_cloudpickle_for(learner_type, learner_kwargs):
+    """Test serializing a learner using cloudpickle.
+
+    We use cloudpickle because with pickle the functions are only
+    pickled by reference."""
+
+    def f(x):
+        return random.random()
+
+    learner = learner_type(f, **learner_kwargs)
+
+    simple(learner, goal_1)
+    learner_bytes = cloudpickle.dumps(learner)
+
+    # Delete references
+    del f
+    del learner
+
+    learner_loaded = cloudpickle.loads(learner_bytes)
+    assert learner_loaded.npoints >= 10
+    simple(learner_loaded, goal_2)
+    assert learner_loaded.npoints >= 20
+
+
+def test_cloudpickle_for_datasaver():
+    def f(x):
+        return dict(x=1, y=x ** 2)
+
+    _learner = Learner1D(f, bounds=(-1, 1))
+    learner = DataSaver(_learner, arg_picker=lambda x: x["y"])
+
+    simple(learner, goal_1)
+    learner_bytes = cloudpickle.dumps(learner)
+
+    # Delete references
+    del f
+    del _learner
+    del learner
+
+    learner_loaded = cloudpickle.loads(learner_bytes)
+    assert learner_loaded.npoints >= 10
+    simple(learner_loaded, goal_2)
+    assert learner_loaded.npoints >= 20
+
+
+def test_cloudpickle_for_balancing_learner():
+    def f(x):
+        return x ** 2
+
+    learner_1 = Learner1D(f, bounds=(-1, 1))
+    learner_2 = Learner1D(f, bounds=(-2, 2))
+    learner = BalancingLearner([learner_1, learner_2])
+
+    simple(learner, goal_1)
+    learner_bytes = cloudpickle.dumps(learner)
+
+    # Delete references
+    del f
+    del learner_1
+    del learner_2
+    del learner
+
+    learner_loaded = cloudpickle.loads(learner_bytes)
+    assert learner_loaded.npoints >= 10
+    simple(learner_loaded, goal_2)
+    assert learner_loaded.npoints >= 20

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -2,7 +2,6 @@ import operator
 import pickle
 import random
 
-import flaky
 import pytest
 
 from adaptive.learner import (
@@ -70,7 +69,6 @@ def f_for_pickle_datasaver(x):
     return dict(x=x, y=x)
 
 
-@flaky.flaky(max_runs=3)
 @pytest.mark.parametrize(
     "learner_type, learner_kwargs, serializer", learners,
 )
@@ -85,8 +83,6 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
         f = f_for_pickle  # noqa: F811
 
     learner = learner_type(f, **learner_kwargs)
-    if learner_type is Learner1D:
-        learner._recompute_losses_factor = 1
 
     simple(learner, goal_1)
     learner_bytes = serializer.dumps(learner)
@@ -102,12 +98,9 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
     assert learner_loaded.npoints == 10
     assert loss == learner_loaded.loss()
 
-    if learner_type is not Learner2D:
-        # cannot test this for Learner2D because
-        # xfailing test_point_adding_order_is_irrelevant
-        assert asked == learner_loaded.ask(1)
-        # load again to undo the ask
-        learner_loaded = serializer.loads(learner_bytes)
+    assert asked == learner_loaded.ask(1)
+    # load again to undo the ask
+    learner_loaded = serializer.loads(learner_bytes)
 
     simple(learner_loaded, goal_2)
     assert learner_loaded.npoints == 20

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -33,11 +33,11 @@ except ModuleNotFoundError:
 
 
 def goal_1(learner):
-    return learner.npoints >= 10
+    return learner.npoints == 10
 
 
 def goal_2(learner):
-    return learner.npoints >= 20
+    return learner.npoints == 20
 
 
 learners_pairs = [
@@ -97,7 +97,7 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
         del learner
 
     learner_loaded = serializer.loads(learner_bytes)
-    assert learner_loaded.npoints >= 10
+    assert learner_loaded.npoints == 10
     assert loss == learner_loaded.loss()
 
     if learner_type is not Learner2D:
@@ -108,7 +108,7 @@ def test_serialization_for(learner_type, learner_kwargs, serializer):
         learner_loaded = serializer.loads(learner_bytes)
 
     simple(learner_loaded, goal_2)
-    assert learner_loaded.npoints >= 20
+    assert learner_loaded.npoints == 20
 
 
 @pytest.mark.parametrize(

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -137,9 +137,9 @@ def test_serialization_for_datasaver(serializer):
         del learner
 
     learner_loaded = serializer.loads(learner_bytes)
-    assert learner_loaded.npoints >= 10
+    assert learner_loaded.npoints == 10
     simple(learner_loaded, goal_2)
-    assert learner_loaded.npoints >= 20
+    assert learner_loaded.npoints == 20
 
 
 @pytest.mark.parametrize(
@@ -168,6 +168,6 @@ def test_serialization_for_balancing_learner(serializer):
         del learner
 
     learner_loaded = serializer.loads(learner_bytes)
-    assert learner_loaded.npoints >= 10
+    assert learner_loaded.npoints == 10
     simple(learner_loaded, goal_2)
-    assert learner_loaded.npoints >= 20
+    assert learner_loaded.npoints == 20

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ extras_require = {
         "plotly",
     ],
     "testing": [
+        "cloudpickle",
         "flaky",
         "pytest",
         "pytest-cov",
@@ -51,8 +52,8 @@ extras_require = {
         "pre_commit",
     ],
     "other": [
-        "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404
         "distributed",
+        "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404
         "loky",
         "scikit-optimize",
         "wexpect" if os.name == "nt" else "pexpect",

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,6 @@ extras_require = {
         "plotly",
     ],
     "testing": [
-        "cloudpickle",
-        "dill",
         "flaky",
         "pytest",
         "pytest-cov",
@@ -53,6 +51,8 @@ extras_require = {
         "pre_commit",
     ],
     "other": [
+        "cloudpickle",
+        "dill",
         "distributed",
         "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404
         "loky",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ extras_require = {
     ],
     "testing": [
         "cloudpickle",
+        "dill",
         "flaky",
         "pytest",
         "pytest-cov",

--- a/tox.ini
+++ b/tox.ini
@@ -65,4 +65,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=PIL,atomicwrites,cloudpickle,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers
+known_third_party=PIL,atomicwrites,cloudpickle,dill,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers

--- a/tox.ini
+++ b/tox.ini
@@ -65,4 +65,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=PIL,atomicwrites,cloudpickle,dill,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers
+known_third_party=PIL,atomicwrites,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers

--- a/tox.ini
+++ b/tox.ini
@@ -65,4 +65,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=PIL,atomicwrites,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers
+known_third_party=PIL,atomicwrites,cloudpickle,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers


### PR DESCRIPTION
## Description

I realized that in some cases it's very useful to pickle learners. For example to send it over the network when parallelizing code.

With these changes, most learners become picklable.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
