### PR TITLE
Make SequenceLearner points hashable by passing the sequence to the function.

### DIFF
--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -6,14 +6,7 @@ from adaptive.learner.base_learner import BaseLearner
 
 
 class _IndexToPoint:
-    """Call function with index of sequence.
-
-    The SequenceLearner's function receives a tuple ``(index, point)``
-    but the original function only takes ``point``.
-
-    This is the same as `lambda x: function(x[1])`, however, that is not
-    pickable.
-    """
+    """Call function with index of sequence."""
 
     def __init__(self, function, sequence):
         self.function = function

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -5,7 +5,7 @@ from sortedcontainers import SortedDict, SortedSet
 from adaptive.learner.base_learner import BaseLearner
 
 
-class _IndexToPoint:
+class _CallFromSequence:
     """Call function with index of sequence."""
 
     def __init__(self, function, sequence):
@@ -45,7 +45,7 @@ class SequenceLearner(BaseLearner):
 
     def __init__(self, function, sequence):
         self._original_function = function
-        self.function = _IndexToPoint(function, sequence)
+        self.function = _CallFromSequence(function, sequence)
         self._to_do_indices = SortedSet({i for i, _ in enumerate(sequence)})
         self._ntotal = len(sequence)
         self.sequence = copy(sequence)

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -22,12 +22,6 @@ class _IndexToPoint:
     def __call__(self, index, *args, **kwargs):
         return self.function(self.sequence[index], *args, **kwargs)
 
-    def __getstate__(self):
-        return self.function, self.sequence
-
-    def __setstate__(self, state):
-        self.__init__(*state)
-
 
 class SequenceLearner(BaseLearner):
     r"""A learner that will learn a sequence. It simply returns

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -20,8 +20,7 @@ class _IndexToPoint:
         self.sequence = sequence
 
     def __call__(self, index, *args, **kwargs):
-        point = self.sequence[index]
-        return self.function(point, *args, **kwargs)
+        return self.function(self.sequence[index], *args, **kwargs)
 
     def __getstate__(self):
         return self.function, self.sequence

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -281,19 +281,9 @@ def test_adding_existing_data_is_idempotent(learner_type, f, learner_kwargs):
     M = random.randint(10, 30)
     pls = zip(*learner.ask(M))
     cpls = zip(*control.ask(M))
-    if learner_type is SequenceLearner:
-        # The SequenceLearner's points might not be hasable
-        points, values = zip(*pls)
-        indices, points = zip(*points)
 
-        cpoints, cvalues = zip(*cpls)
-        cindices, cpoints = zip(*cpoints)
-        assert (np.array(points) == np.array(cpoints)).all()
-        assert values == cvalues
-        assert indices == cindices
-    else:
-        # Point ordering is not defined, so compare as sets
-        assert set(pls) == set(cpls)
+    # Point ordering is not defined, so compare as sets
+    assert set(pls) == set(cpls)
 
 
 # XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
@@ -324,20 +314,9 @@ def test_adding_non_chosen_data(learner_type, f, learner_kwargs):
     pls = zip(*learner.ask(M))
     cpls = zip(*control.ask(M))
 
-    if learner_type is SequenceLearner:
-        # The SequenceLearner's points might not be hasable
-        points, values = zip(*pls)
-        indices, points = zip(*points)
-
-        cpoints, cvalues = zip(*cpls)
-        cindices, cpoints = zip(*cpoints)
-        assert (np.array(points) == np.array(cpoints)).all()
-        assert values == cvalues
-        assert indices == cindices
-    else:
-        # Point ordering within a single call to 'ask'
-        # is not guaranteed to be the same by the API.
-        assert set(pls) == set(cpls)
+    # Point ordering within a single call to 'ask'
+    # is not guaranteed to be the same by the API.
+    assert set(pls) == set(cpls)
 
 
 @run_with(Learner1D, xfail(Learner2D), xfail(LearnerND), AverageLearner)

--- a/adaptive/tests/test_sequence_learner.py
+++ b/adaptive/tests/test_sequence_learner.py
@@ -2,23 +2,27 @@ import asyncio
 
 import numpy as np
 
-import adaptive
+from adaptive import Runner, SequenceLearner
+from adaptive.runner import SequentialExecutor
 
 
-def might_fail(dct):
-    import random
+class FailOnce:
+    def __init__(self):
+        self.failed = False
 
-    if random.random() < 0.5:
-        raise Exception()
-    return dct["x"]
+    def __call__(self, value):
+        if self.failed:
+            return value
+        self.failed = True
+        raise Exception
 
 
 def test_fail_with_sequence_of_unhashable():
     # https://github.com/python-adaptive/adaptive/issues/265
     seq = [dict(x=x) for x in np.linspace(-1, 1, 101)]  # unhashable
-    learner = adaptive.SequenceLearner(might_fail, sequence=seq)
-    runner = adaptive.Runner(
-        learner, goal=adaptive.SequenceLearner.done, retries=100
+    learner = SequenceLearner(FailOnce(), sequence=seq)
+    runner = Runner(
+        learner, goal=SequenceLearner.done, retries=100, executor=SequentialExecutor()
     )  # with 100 retries the test will fail once in 10^31
     asyncio.get_event_loop().run_until_complete(runner.task)
     assert runner.status() == "finished"

--- a/adaptive/tests/test_sequence_learner.py
+++ b/adaptive/tests/test_sequence_learner.py
@@ -1,0 +1,24 @@
+import asyncio
+
+import numpy as np
+
+import adaptive
+
+
+def might_fail(dct):
+    import random
+
+    if random.random() < 0.5:
+        raise Exception()
+    return dct["x"]
+
+
+def test_fail_with_sequence_of_unhashable():
+    # https://github.com/python-adaptive/adaptive/issues/265
+    seq = [dict(x=x) for x in np.linspace(-1, 1, 101)]  # unhashable
+    learner = adaptive.SequenceLearner(might_fail, sequence=seq)
+    runner = adaptive.Runner(
+        learner, goal=adaptive.SequenceLearner.done, retries=100
+    )  # with 100 retries the test will fail once in 10^31
+    asyncio.get_event_loop().run_until_complete(runner.task)
+    assert runner.status() == "finished"

--- a/adaptive/tests/test_sequence_learner.py
+++ b/adaptive/tests/test_sequence_learner.py
@@ -1,7 +1,5 @@
 import asyncio
 
-import numpy as np
-
 from adaptive import Runner, SequenceLearner
 from adaptive.runner import SequentialExecutor
 
@@ -14,15 +12,15 @@ class FailOnce:
         if self.failed:
             return value
         self.failed = True
-        raise Exception
+        raise RuntimeError
 
 
 def test_fail_with_sequence_of_unhashable():
     # https://github.com/python-adaptive/adaptive/issues/265
-    seq = [dict(x=x) for x in np.linspace(-1, 1, 101)]  # unhashable
+    seq = [{1: 1}]  # unhashable
     learner = SequenceLearner(FailOnce(), sequence=seq)
     runner = Runner(
-        learner, goal=SequenceLearner.done, retries=100, executor=SequentialExecutor()
-    )  # with 100 retries the test will fail once in 10^31
+        learner, goal=SequenceLearner.done, retries=1, executor=SequentialExecutor()
+    )
     asyncio.get_event_loop().run_until_complete(runner.task)
     assert runner.status() == "finished"


### PR DESCRIPTION
## Description

With this change, the function of the `SequenceLearner` contains the sequence.

This is needed because points that are passed to the `Runner` **need** to be hashable, and this is not required by the entries of the `sequence` in `SequenceLearner`.

Fixes https://github.com/python-adaptive/adaptive/issues/265

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
