### PR TITLE
minimally require ipyparallel 6.2.5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - sortedcollections
   - scipy
   - holoviews
-  - ipyparallel
+  - ipyparallel>=6.2.5
   - distributed
   - ipykernel>=4.8*
   - loky

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
         "pre_commit",
     ],
     "other": [
-        "ipyparallel",
+        "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404
         "distributed",
         "loky",
         "scikit-optimize",


### PR DESCRIPTION
## Description

This means that we won't run into https://github.com/joblib/loky/issues/240


~~This can be merged when ipyparallel 6.2.5 is on conda-forge.~~
On conda-forge now: https://github.com/conda-forge/ipyparallel-feedstock/pull/48

Fixes #249.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
