### PR TITLE
Learner1D: return inf loss when the bounds aren't done

### DIFF
--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -1,7 +1,7 @@
 import collections.abc
 import itertools
 import math
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple, Union
 
 import cloudpickle
@@ -290,6 +290,7 @@ class Learner1D(BaseLearner):
         self._dx_eps = 2 * max(np.abs(bounds)) * np.finfo(float).eps
 
         self.bounds = list(bounds)
+        self.__missing_bounds = set(self.bounds)  # cache of missing bounds
 
         self._vdim: Optional[int] = None
 
@@ -325,6 +326,8 @@ class Learner1D(BaseLearner):
 
     @cache_latest
     def loss(self, real: bool = True) -> float:
+        if self.__missing_bounds:
+            return np.inf
         losses = self.losses if real else self.losses_combined
         if not losses:
             return np.inf
@@ -604,6 +607,15 @@ class Learner1D(BaseLearner):
 
         return points, loss_improvements
 
+    def _missing_bounds(self) -> List[Real]:
+        missing_bounds = []
+        for b in copy(self.__missing_bounds):
+            if b in self.data:
+                self.__missing_bounds.remove(b)
+            elif b not in self.pending_points:
+                missing_bounds.append(b)
+        return missing_bounds
+
     def _ask_points_without_adding(self, n: int) -> Tuple[List[float], List[float]]:
         """Return 'n' points that are expected to maximally reduce the loss.
         Without altering the state of the learner"""
@@ -619,12 +631,7 @@ class Learner1D(BaseLearner):
             return [], []
 
         # If the bounds have not been chosen yet, we choose them first.
-        missing_bounds = [
-            b
-            for b in self.bounds
-            if b not in self.data and b not in self.pending_points
-        ]
-
+        missing_bounds = self._missing_bounds()
         if len(missing_bounds) >= n:
             return missing_bounds[:n], [np.inf] * n
 

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -326,7 +326,7 @@ class Learner1D(BaseLearner):
 
     @cache_latest
     def loss(self, real: bool = True) -> float:
-        if self.__missing_bounds:
+        if self._missing_bounds():
             return np.inf
         losses = self.losses if real else self.losses_combined
         if not losses:

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -614,7 +614,7 @@ class Learner1D(BaseLearner):
                 self.__missing_bounds.remove(b)
             elif b not in self.pending_points:
                 missing_bounds.append(b)
-        return missing_bounds
+        return sorted(missing_bounds)
 
     def _ask_points_without_adding(self, n: int) -> Tuple[List[float], List[float]]:
         """Return 'n' points that are expected to maximally reduce the loss.

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -9,6 +9,15 @@ from adaptive.learner.learner1D import curvature_loss_function
 from adaptive.runner import BlockingRunner, simple
 
 
+def flat_middle(x):
+    x *= 1e7
+    xs = np.array([0.0, 0.1, 0.9, 1.0])
+    ys = [0, 1, 1, 0]
+    if x < xs[1] or x > xs[-2]:
+        time.sleep(1)
+    return np.interp(x, xs, ys)
+
+
 def test_pending_loss_intervals():
     # https://github.com/python-adaptive/adaptive/issues/40
     learner = Learner1D(lambda x: x, (0, 4))
@@ -393,14 +402,6 @@ def test_NaN_loss():
 
 
 def test_inf_loss_with_missing_bounds():
-    def flat_middle(x):
-        x *= 1e7
-        xs = np.array([0.0, 0.1, 0.9, 1.0])
-        ys = [0, 1, 1, 0]
-        if x < xs[1] or x > xs[-2]:
-            time.sleep(1)
-        return np.interp(x, xs, ys)
-
     learner = Learner1D(
         flat_middle,
         bounds=(0, 1e-7),

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -1,11 +1,12 @@
 import random
+import time
 
 import flaky
 import numpy as np
 
 from adaptive.learner import Learner1D
 from adaptive.learner.learner1D import curvature_loss_function
-from adaptive.runner import simple
+from adaptive.runner import BlockingRunner, simple
 
 
 def test_pending_loss_intervals():
@@ -389,3 +390,23 @@ def test_NaN_loss():
 
     learner = Learner1D(f, bounds=(-1, 1))
     simple(learner, lambda l: l.npoints > 100)
+
+
+def test_inf_loss_with_missing_bounds():
+    def flat_middle(x):
+        x *= 1e7
+        xs = np.array([0.0, 0.1, 0.9, 1.0])
+        ys = [0, 1, 1, 0]
+        if x < xs[1] or x > xs[-2]:
+            time.sleep(1)
+        return np.interp(x, xs, ys)
+
+    learner = Learner1D(
+        flat_middle,
+        bounds=(0, 1e-7),
+        loss_per_interval=curvature_loss_function(),
+    )
+    # must be done in parallel because otherwise the bounds will be evaluated first
+    BlockingRunner(learner, goal=lambda learner: learner.loss() < 0.01)
+
+    learner.npoints > 20


### PR DESCRIPTION
## Description

@bernardvanheck found an issue that occurs when using multiple cores on the following function
![image](https://user-images.githubusercontent.com/6897215/79739852-0fb4cd00-82ff-11ea-87b2-5f4d34c59819.png)
Here the middle region is exponentially flat and the blue curve is a homogeneous plot and the orange points are of the finished learner with a very small loss (<0.01).

I think that a learner should report an infinite loss whenever the bounds aren't included.

Having that, means that the issue I described above is much less likely to occur.

The following code snippet results in a learner with a small loss after only 3 points.
```
import adaptive
from adaptive.learner.learner1D import curvature_loss_function, Learner1D
from adaptive.runner import replay_log

learner_fail = Learner1D(
    lambda x: x, bounds=(-400e-6, 400e-6), loss_per_interval=curvature_loss_function(),
)

# The first returning points are in the middle flat region.
runner_log = [
    ("ask", 4),
    ("tell", 0.00013333333333333334, 1.9998184085251902),
    ("ask", 1),
    ("tell", -0.00013333333333333334, 1.9998184085251902),
    ("ask", 1),
    ("tell", 0.0, 1.9998184085251902),
]
replay_log(learner_fail, runner_log)

runner = adaptive.BlockingRunner(learner_fail, goal=lambda learner: learner.loss() < 0.01, log=True)
```


## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
