### PR TITLE
prevent ImportError due to scikit-optimize and sklearn incompatibility

### DIFF
--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -30,7 +30,7 @@ from adaptive.runner import simple
 try:
     from adaptive.learner.skopt_learner import SKOptLearner
 except (ModuleNotFoundError, ImportError):
-    # XXX: catch the ImportError because of https://github.com/python-adaptive/adaptive/pull/278
+    # XXX: catch the ImportError because of https://github.com/scikit-optimize/scikit-optimize/issues/902
     SKOptLearner = None
 
 

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -30,6 +30,7 @@ from adaptive.runner import simple
 try:
     from adaptive.learner.skopt_learner import SKOptLearner
 except (ModuleNotFoundError, ImportError):
+    # XXX: catch the ImportError because of https://github.com/python-adaptive/adaptive/pull/278
     SKOptLearner = None
 
 

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -29,7 +29,7 @@ from adaptive.runner import simple
 
 try:
     from adaptive.learner.skopt_learner import SKOptLearner
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     SKOptLearner = None
 
 


### PR DESCRIPTION
## Description

All tests fail with
```bash
______________ ERROR collecting adaptive/tests/test_learnernd.py ______________
ImportError while importing test module 'D:\a\1\s\adaptive\tests\test_learnernd.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
.tox\py36-alldeps\lib\site-packages\_pytest\python.py:511: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
.tox\py36-alldeps\lib\site-packages\py\_path\local.py:701: in pyimport
    __import__(modname)
.tox\py36-alldeps\lib\site-packages\_pytest\assertion\rewrite.py:152: in exec_module
    exec(co, module.__dict__)
adaptive\tests\test_learnernd.py:7: in <module>
    from .test_learners import generate_random_parametrization, ring_of_fire
.tox\py36-alldeps\lib\site-packages\_pytest\assertion\rewrite.py:152: in exec_module
    exec(co, module.__dict__)
adaptive\tests\test_learners.py:31: in <module>
    from adaptive.learner.skopt_learner import SKOptLearner
adaptive\learner\skopt_learner.py:4: in <module>
    from skopt import Optimizer
.tox\py36-alldeps\lib\site-packages\skopt\__init__.py:54: in <module>
    from .searchcv import BayesSearchCV
.tox\py36-alldeps\lib\site-packages\skopt\searchcv.py:16: in <module>
    from sklearn.utils.fixes import MaskedArray
E   ImportError: cannot import name 'MaskedArray'
```

See https://github.com/scikit-optimize/scikit-optimize/issues/902

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
