### PR TITLE
always serialize the function using cloudpickle

### DIFF
--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -1,5 +1,6 @@
 from math import sqrt
 
+import cloudpickle
 import numpy as np
 
 from adaptive.learner.base_learner import BaseLearner
@@ -151,7 +152,7 @@ class AverageLearner(BaseLearner):
 
     def __getstate__(self):
         return (
-            self.function,
+            cloudpickle.dumps(self.function),
             self.atol,
             self.rtol,
             self.min_npoints,
@@ -160,5 +161,6 @@ class AverageLearner(BaseLearner):
 
     def __setstate__(self, state):
         function, atol, rtol, min_npoints, data = state
+        function = cloudpickle.loads(function)
         self.__init__(function, atol, rtol, min_npoints)
         self._set_data(data)

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from math import sqrt
 from operator import attrgetter
 
+import cloudpickle
 import numpy as np
 from scipy.linalg import norm
 from sortedcontainers import SortedSet
@@ -594,7 +595,7 @@ class IntegratorLearner(BaseLearner):
 
     def __getstate__(self):
         return (
-            self.function,
+            cloudpickle.dumps(self.function),
             self.bounds,
             self.tol,
             self._get_data(),
@@ -602,5 +603,6 @@ class IntegratorLearner(BaseLearner):
 
     def __setstate__(self, state):
         function, bounds, tol, data = state
+        function = cloudpickle.loads(function)
         self.__init__(function, bounds, tol)
         self._set_data(data)

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -3,6 +3,7 @@ import math
 from collections.abc import Iterable
 from copy import deepcopy
 
+import cloudpickle
 import numpy as np
 import sortedcollections
 import sortedcontainers
@@ -627,7 +628,7 @@ class Learner1D(BaseLearner):
 
     def __getstate__(self):
         return (
-            self.function,
+            cloudpickle.dumps(self.function),
             self.bounds,
             self.loss_per_interval,
             dict(self.losses),  # SortedDict cannot be pickled
@@ -637,6 +638,7 @@ class Learner1D(BaseLearner):
 
     def __setstate__(self, state):
         function, bounds, loss_per_interval, losses, losses_combined, data = state
+        function = cloudpickle.loads(function)
         self.__init__(function, bounds, loss_per_interval)
         self._set_data(data)
         self.losses.update(losses)

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from copy import copy
 from math import sqrt
 
+import cloudpickle
 import numpy as np
 from scipy import interpolate
 
@@ -709,7 +710,7 @@ class Learner2D(BaseLearner):
 
     def __getstate__(self):
         return (
-            self.function,
+            cloudpickle.dumps(self.function),
             self.bounds,
             self.loss_per_triangle,
             self._stack,
@@ -718,6 +719,7 @@ class Learner2D(BaseLearner):
 
     def __setstate__(self, state):
         function, bounds, loss_per_triangle, _stack, data = state
+        function = cloudpickle.loads(function)
         self.__init__(function, bounds, loss_per_triangle)
         self._set_data(data)
         self._stack = _stack

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -1,5 +1,6 @@
 from copy import copy
 
+import cloudpickle
 from sortedcontainers import SortedDict, SortedSet
 
 from adaptive.learner.base_learner import BaseLearner
@@ -131,12 +132,13 @@ class SequenceLearner(BaseLearner):
 
     def __getstate__(self):
         return (
-            self._original_function,
+            cloudpickle.dumps(self._original_function),
             self.sequence,
             self._get_data(),
         )
 
     def __setstate__(self, state):
         function, sequence, data = state
+        function = cloudpickle.loads(function)
         self.__init__(function, sequence)
         self._set_data(data)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     "sortedcollections >= 1.1",
     "sortedcontainers >= 2.0",
     "atomicwrites",
+    "cloudpickle",
 ]
 
 extras_require = {
@@ -51,7 +52,6 @@ extras_require = {
         "pre_commit",
     ],
     "other": [
-        "cloudpickle",
         "dill",
         "distributed",
         "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404

--- a/tox.ini
+++ b/tox.ini
@@ -65,4 +65,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=PIL,atomicwrites,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers
+known_third_party=PIL,atomicwrites,cloudpickle,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers


### PR DESCRIPTION
## Description

This was a suggestion of @jbweston some time ago.

Using this, the learners are picklable regardless of the serialization package chosen.

This also means that we can e.g. use lambda functions when using a `ProcessPoolExecutor` and do not need `loky` per se.

I am making these changes now because I am finding that in some cases it's not preferable to use `cloudpickle` to serialize simple dictionaries (see https://github.com/cloudpipe/cloudpickle/issues/375).

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
