### PR TITLE
temporarily pin scikit-learn<=0.23.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ extras_require = {
         "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404
         "loky",
         "scikit-optimize",
+        "scikit-learn<=0.23.1",  # because of https://github.com/scikit-optimize/scikit-optimize/issues/931, remove dep when fixed
         "wexpect" if os.name == "nt" else "pexpect",
     ],
 }


### PR DESCRIPTION
## Description

Builds are failing.

See https://github.com/scikit-optimize/scikit-optimize/issues/931

Fixes #(ISSUE_NUMBER_HERE)

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
