### PR TITLE
update to miniver 0.7.0

### DIFF
--- a/adaptive/_version.py
+++ b/adaptive/_version.py
@@ -3,8 +3,8 @@
 import os
 import subprocess
 from collections import namedtuple
-from distutils.command.build_py import build_py as build_py_orig
 
+from setuptools.command.build_py import build_py as build_py_orig
 from setuptools.command.sdist import sdist as sdist_orig
 
 Version = namedtuple("Version", ("release", "dev", "labels"))
@@ -15,6 +15,13 @@ __all__ = []
 package_root = os.path.dirname(os.path.realpath(__file__))
 package_name = os.path.basename(package_root)
 distr_root = os.path.dirname(package_root)
+# If the package is inside a "src" directory the
+# distribution root is 1 level up.
+if os.path.split(distr_root)[1] == "src":
+    _package_root_inside_src = True
+    distr_root = os.path.dirname(distr_root)
+else:
+    _package_root_inside_src = False
 
 STATIC_VERSION_FILE = "_static_version.py"
 
@@ -189,7 +196,11 @@ class _build_py(build_py_orig):
 class _sdist(sdist_orig):
     def make_release_tree(self, base_dir, files):
         super().make_release_tree(base_dir, files)
-        _write_version(os.path.join(base_dir, package_name, STATIC_VERSION_FILE))
+        if _package_root_inside_src:
+            p = os.path.join("src", package_name)
+        else:
+            p = package_name
+        _write_version(os.path.join(base_dir, p, STATIC_VERSION_FILE))
 
 
 cmdclass = dict(sdist=_sdist, build_py=_build_py)


### PR DESCRIPTION
## Description

Fixes warning printed:
```
/gscratch/home/a-banijh/miniconda3/envs/py38/lib/python3.8/site-packages/setuptools/distutils_patch.py:25: UserWarning: Distutils was imported before Setuptools. This usage is discouraged and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools first.
  warnings.warn(
```

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
