### PR TITLE
bump pre-commit filter dependencies and add blacken-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,33 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-        -   id: check-docstring-first
-        -   id: check-ast
-        -   id: check-json
-        -   id: check-yaml
-        -   id: debug-statements
-        -   id: end-of-file-fixer
-        -   id: trailing-whitespace
--   repo: https://github.com/ambv/black
-    rev: 19.10b0
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-docstring-first
+    - id: check-yaml
+    - id: debug-statements
+    - id: check-ast
+  - repo: https://github.com/ambv/black
+    rev: 20.8b1
     hooks:
     - id: black
-      language_version: python3.7
--   repo: https://github.com/asottile/pyupgrade
+  - repo: https://github.com/asottile/blacken-docs
+    rev: v1.8.0
+    hooks:
+    - id: blacken-docs
+      additional_dependencies: [black==20.8b1]
+  - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.2
     hooks:
-    -   id: pyupgrade
-        args: ['--py36-plus']
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
+    - id: pyupgrade
+      args: ['--py36-plus']
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.5.2
     hooks:
-    -   id: seed-isort-config
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.3.2
-    hooks:
-    -   id: isort
--   repo: https://gitlab.com/pycqa/flake8
+    - id: isort
+  - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:
-    -   id: flake8
+    - id: flake8
+      args: ['--config=tox.ini']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,6 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
-  - repo: https://github.com/asottile/blacken-docs
-    rev: v1.8.0
-    hooks:
-    - id: blacken-docs
-      additional_dependencies: [black==20.8b1]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.7.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.3.0
     hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer
@@ -18,16 +18,16 @@ repos:
     - id: blacken-docs
       additional_dependencies: [black==20.8b1]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
+    rev: v2.7.3
     hooks:
     - id: pyupgrade
       args: ['--py36-plus']
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.5.2
+    rev: 5.6.4
     hooks:
     - id: isort
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.8.4
     hooks:
     - id: flake8
       args: ['--config=tox.ini']

--- a/adaptive/tests/test_cquad.py
+++ b/adaptive/tests/test_cquad.py
@@ -242,7 +242,7 @@ def test_approximating_intervals():
 @pytest.mark.xfail
 def test_removed_choose_mutiple_points_at_once():
     """Given that a high-precision interval that was split into 2 low-precision ones,
-       we should use the high-precision interval.
+    we should use the high-precision interval.
     """
     learner = IntegratorLearner(np.exp, bounds=(0, 1), tol=1e-15)
     n = ns[-1] + 2 * (ns[0] - 2)  # first + two children (33+6=39)

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -626,6 +626,6 @@ def test_convergence_for_arbitrary_ordering(learner_type, f, learner_kwargs):
 @run_with(Learner1D, Learner2D, LearnerND)
 def test_learner_subdomain(learner_type, f, learner_kwargs):
     """Learners that never receive data outside of a subdomain should
-       perform 'similarly' to learners defined on that subdomain only."""
+    perform 'similarly' to learners defined on that subdomain only."""
     # XXX: not sure how to implement this. How do we measure "performance"?
     raise NotImplementedError()

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -86,9 +86,7 @@ learners = [
 ]
 
 
-@pytest.mark.parametrize(
-    "learner_type, learner_kwargs, serializer, f", learners,
-)
+@pytest.mark.parametrize("learner_type, learner_kwargs, serializer, f", learners)
 def test_serialization_for(learner_type, learner_kwargs, serializer, f):
     """Test serializing a learner using different serializers."""
 

--- a/adaptive/tests/test_skopt_learner.py
+++ b/adaptive/tests/test_skopt_learner.py
@@ -12,7 +12,7 @@ except ModuleNotFoundError:
 @pytest.mark.skipif(not with_scikit_optimize, reason="scikit-optimize is not installed")
 def test_skopt_learner_runs():
     """The SKOptLearner provides very few guarantees about its
-       behaviour, so we only test the most basic usage
+    behaviour, so we only test the most basic usage
     """
 
     def g(x, noise_level=0.1):
@@ -28,8 +28,8 @@ def test_skopt_learner_runs():
 @pytest.mark.skipif(not with_scikit_optimize, reason="scikit-optimize is not installed")
 def test_skopt_learner_4D_runs():
     """The SKOptLearner provides very few guarantees about its
-       behaviour, so we only test the most basic usage
-       In this case we test also for 4D domain
+    behaviour, so we only test the most basic usage
+    In this case we test also for 4D domain
     """
 
     def g(x, noise_level=0.1):

--- a/tox.ini
+++ b/tox.ini
@@ -60,9 +60,4 @@ select = B, C, E, F, W, T4, B9
 exclude = .git, .tox, __pycache__, dist
 
 [isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-known_third_party=PIL,atomicwrites,flaky,holoviews,matplotlib,nbconvert,numpy,pytest,scipy,setuptools,skopt,sortedcollections,sortedcontainers
+profile=black


### PR DESCRIPTION
## Description

Also adds blacken-docs.

I've added support for Jupyter Sphinx here https://github.com/asottile/blacken-docs/pull/37.

Blacken-docs is failing, this PR will fix that: https://github.com/asottile/blacken-docs/pull/57

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
