### PR TITLE
make loky a default on Windows and MacOS but not on Linux

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -49,9 +49,9 @@ else:
     # On Windows and MacOS functions, the __main__ module must be
     # importable by worker subprocesses. This means that
     # ProcessPoolExecutor will not work in the interactive interpreter.
-    # On Linux the whole environment is forked, so the issue does
-    # not appear.
+    # On Linux the whole process is forked, so the issue does not appear.
     # See https://docs.python.org/3/library/concurrent.futures.html#processpoolexecutor
+    # and https://github.com/python-adaptive/adaptive/issues/301
     _default_executor = loky.get_reusable_executor
 
 
@@ -69,7 +69,8 @@ class BaseRunner(metaclass=abc.ABCMeta):
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional
         The executor in which to evaluate the function to be learned.
-        If not provided, a new `~concurrent.futures.ProcessPoolExecutor`.
+        If not provided, a new `~concurrent.futures.ProcessPoolExecutor` on
+        Linux, and a `loky.get_reusable_executor` on MacOS and Windows.
     ntasks : int, optional
         The number of concurrent function evaluations. Defaults to the number
         of cores available in `executor`.
@@ -321,7 +322,8 @@ class BlockingRunner(BaseRunner):
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional
         The executor in which to evaluate the function to be learned.
-        If not provided, a new `~concurrent.futures.ProcessPoolExecutor`.
+        If not provided, a new `~concurrent.futures.ProcessPoolExecutor` on
+        Linux, and a `loky.get_reusable_executor` on MacOS and Windows.
     ntasks : int, optional
         The number of concurrent function evaluations. Defaults to the number
         of cores available in `executor`.
@@ -437,7 +439,8 @@ class AsyncRunner(BaseRunner):
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional
         The executor in which to evaluate the function to be learned.
-        If not provided, a new `~concurrent.futures.ProcessPoolExecutor`.
+        If not provided, a new `~concurrent.futures.ProcessPoolExecutor` on
+        Linux, and a `loky.get_reusable_executor` on MacOS and Windows.
     ntasks : int, optional
         The number of concurrent function evaluations. Defaults to the number
         of cores available in `executor`.

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -15,7 +15,6 @@ from adaptive.runner import (
     stop_after,
     with_distributed,
     with_ipyparallel,
-    with_loky,
 )
 
 
@@ -139,7 +138,6 @@ def test_distributed_executor():
     assert learner.npoints > 0
 
 
-@pytest.mark.skipif(not with_loky, reason="loky not installed")
 def test_loky_executor(loky_executor):
     learner = Learner1D(lambda x: x, (-1, 1))
     BlockingRunner(

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -1,5 +1,5 @@
 import asyncio
-import os
+import platform
 import sys
 import time
 
@@ -16,6 +16,8 @@ from adaptive.runner import (
     with_distributed,
     with_ipyparallel,
 )
+
+OPERATING_SYSTEM = platform.system()
 
 
 def blocking_runner(learner, goal):
@@ -72,22 +74,6 @@ def test_aync_def_function():
 
 
 @pytest.fixture(scope="session")
-def ipyparallel_executor():
-    from ipyparallel import Client
-
-    if os.name == "nt":
-        import wexpect as expect
-    else:
-        import pexpect as expect
-
-    child = expect.spawn("ipcluster start -n 1")
-    child.expect("Engines appear to have started successfully", timeout=35)
-    yield Client()
-    if not child.terminate(force=True):
-        raise RuntimeError("Could not stop ipcluster")
-
-
-@pytest.fixture(scope="session")
 def loky_executor():
     import loky
 
@@ -117,17 +103,35 @@ def test_stop_after_goal():
 
 
 @pytest.mark.skipif(not with_ipyparallel, reason="IPyparallel is not installed")
-def test_ipyparallel_executor(ipyparallel_executor):
+@pytest.mark.skipif(
+    OPERATING_SYSTEM == "Windows" and sys.version_info >= (3, 7),
+    reason="Gets stuck in CI",
+)
+def test_ipyparallel_executor():
+    from ipyparallel import Client
+
+    if OPERATING_SYSTEM == "Windows":
+        import wexpect as expect
+    else:
+        import pexpect as expect
+
+    child = expect.spawn("ipcluster start -n 1")
+    child.expect("Engines appear to have started successfully", timeout=35)
+    ipyparallel_executor = Client()
     learner = Learner1D(linear, (-1, 1))
     BlockingRunner(learner, trivial_goal, executor=ipyparallel_executor)
+
     assert learner.npoints > 0
+
+    if not child.terminate(force=True):
+        raise RuntimeError("Could not stop ipcluster")
 
 
 @flaky.flaky(max_runs=5)
 @pytest.mark.timeout(60)
 @pytest.mark.skipif(not with_distributed, reason="dask.distributed is not installed")
-@pytest.mark.skipif(os.name == "nt", reason="XXX: seems to always fail")
-@pytest.mark.skipif(sys.platform == "darwin", reason="XXX: intermittently fails")
+@pytest.mark.skipif(OPERATING_SYSTEM == "Windows", reason="XXX: seems to always fail")
+@pytest.mark.skipif(OPERATING_SYSTEM == "Darwin", reason="XXX: intermittently fails")
 def test_distributed_executor():
     from distributed import Client
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -17,6 +17,6 @@ dependencies:
   - atomicwrites=1.4.0
   - sphinx_fontawesome=0.0.6
   - sphinx=3.2.1
-  - m2r2=0.2.5
+  - m2r2=0.2.7
   - pip:
     - sphinx_rtd_theme

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     "sortedcontainers >= 2.0",
     "atomicwrites",
     "cloudpickle",
+    "loky >= 2.9",
 ]
 
 extras_require = {
@@ -55,7 +56,6 @@ extras_require = {
         "dill",
         "distributed",
         "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404
-        "loky",
         "scikit-optimize>=0.8.1",  # because of https://github.com/scikit-optimize/scikit-optimize/issues/931
         "wexpect" if os.name == "nt" else "pexpect",
     ],


### PR DESCRIPTION
## Description

Make loky a default on Windows and MacOS but not on Linux.

I am doing this because several people have indicated that they are experiencing issues with Loky on a Linux cluster.
On Windows and MacOS loky is preferred because `ProcessPoolExecutor` won't work in interactive environments.

Closes https://github.com/python-adaptive/adaptive/issues/301

See also
- https://github.com/python-adaptive/adaptive/issues/292
- https://github.com/python-adaptive/adaptive/issues/299

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
