### PR TITLE
lazily evaluate the integrator coefficients

### DIFF
--- a/adaptive/learner/integrator_coeffs.py
+++ b/adaptive/learner/integrator_coeffs.py
@@ -2,14 +2,10 @@
 
 from collections import defaultdict
 from fractions import Fraction
+from functools import lru_cache
 
 import numpy as np
 import scipy.linalg
-
-try:
-    from functools import cached_property
-except ImportError:
-    from adaptive.utils import cached_property
 
 
 def legendre(n):
@@ -146,72 +142,48 @@ def calc_V(x, n):
     return np.array(V).T
 
 
-class Coefficients:
-    def __init__(self) -> None:
-        # The nodes
-        self.ns = (5, 9, 17, 33)
+@lru_cache(maxsize=None)
+def _coefficients():
+    eps = np.spacing(1)
 
-        # If the relative difference between two consecutive approximations is
-        # lower than this value, the error estimate is considered reliable.
-        # See section 6.2 of Pedro Gonnet's thesis.
-        self.hint = 0.1
+    # the nodes and Newton polynomials
+    ns = (5, 9, 17, 33)
+    xi = [-np.cos(np.linspace(0, np.pi, n)) for n in ns]
 
-        # Smallest acceptable relative difference of points in a rule.  This was chosen
-        # such that no artifacts are apparent in plots of (i, log(a_i)), where a_i is
-        # the sequence of estimates of the integral value of an interval and all its
-        # ancestors..
-        self.eps = np.spacing(1)
-        self.min_sep = 16 * self.eps
+    # Make `xi` perfectly anti-symmetric, important for splitting the intervals
+    xi = [(row - row[::-1]) / 2 for row in xi]
 
-        # Maximum amount of subdivisions
-        self.ndiv_max = 20
+    # Compute the Vandermonde-like matrix and its inverse.
+    V = [calc_V(x, n) for x, n in zip(xi, ns)]
+    V_inv = list(map(scipy.linalg.inv, V))
+    Vcond = [
+        scipy.linalg.norm(a, 2) * scipy.linalg.norm(b, 2) for a, b in zip(V, V_inv)
+    ]
 
-    @cached_property
-    def xi(self):
-        # The Newton polynomials
-        xi = [-np.cos(np.linspace(0, np.pi, n)) for n in self.ns]
-        # Make `xi` perfectly anti-symmetric, important for splitting the intervals
-        return [(row - row[::-1]) / 2 for row in xi]
+    # Compute the shift matrices.
+    T_left, T_right = [V_inv[3] @ calc_V((xi[3] + a) / 2, ns[3]) for a in [-1, 1]]
 
-    @cached_property
-    def V(self):
-        # Compute the Vandermonde-like matrix and its inverse.
-        return [calc_V(x, n) for x, n in zip(self.xi, self.ns)]
+    # If the relative difference between two consecutive approximations is
+    # lower than this value, the error estimate is considered reliable.
+    # See section 6.2 of Pedro Gonnet's thesis.
+    hint = 0.1
 
-    @cached_property
-    def V_inv(self):
-        # Compute the inverse Vandermonde-like matrix
-        return list(map(scipy.linalg.inv, self.V))
+    # Smallest acceptable relative difference of points in a rule.  This was chosen
+    # such that no artifacts are apparent in plots of (i, log(a_i)), where a_i is
+    # the sequence of estimates of the integral value of an interval and all its
+    # ancestors..
+    min_sep = 16 * eps
 
-    @cached_property
-    def Vcond(self):
-        return [
-            scipy.linalg.norm(a, 2) * scipy.linalg.norm(b, 2)
-            for a, b in zip(self.V, self.V_inv)
-        ]
+    ndiv_max = 20
 
-    @cached_property
-    def k(self):
-        return np.arange(self.ns[3])
+    # set-up the downdate matrix
+    k = np.arange(ns[3])
+    alpha = np.sqrt((k + 1) ** 2 / (2 * k + 1) / (2 * k + 3))
+    gamma = np.concatenate([[0, 0], np.sqrt(k[2:] ** 2 / (4 * k[2:] ** 2 - 1))])
 
-    @cached_property
-    def T_right(self):
-        return self.V_inv[3] @ calc_V((self.xi[3] + 1) / 2, self.ns[3])
+    b_def = calc_bdef(ns)
+    return locals()
 
-    @cached_property
-    def T_left(self):
-        return self.V_inv[3] @ calc_V((self.xi[3] - 1) / 2, self.ns[3])
 
-    @cached_property
-    def alpha(self):
-        return np.sqrt((self.k + 1) ** 2 / (2 * self.k + 1) / (2 * self.k + 3))
-
-    @cached_property
-    def gamma(self):
-        return np.concatenate(
-            [[0, 0], np.sqrt(self.k[2:] ** 2 / (4 * self.k[2:] ** 2 - 1))]
-        )
-
-    @cached_property
-    def b_def(self):
-        return calc_bdef(self.ns)
+def __getattr__(attr):
+    return _coefficients()[attr]

--- a/adaptive/learner/integrator_coeffs.py
+++ b/adaptive/learner/integrator_coeffs.py
@@ -148,10 +148,8 @@ def calc_V(x, n):
 
 class Coefficients:
     def __init__(self) -> None:
-        self.is_set = False
         # The nodes
         self.ns = (5, 9, 17, 33)
-        self.eps = np.spacing(1)
 
         # If the relative difference between two consecutive approximations is
         # lower than this value, the error estimate is considered reliable.
@@ -162,6 +160,7 @@ class Coefficients:
         # such that no artifacts are apparent in plots of (i, log(a_i)), where a_i is
         # the sequence of estimates of the integral value of an interval and all its
         # ancestors..
+        self.eps = np.spacing(1)
         self.min_sep = 16 * self.eps
 
         # Maximum amount of subdivisions

--- a/adaptive/learner/integrator_coeffs.py
+++ b/adaptive/learner/integrator_coeffs.py
@@ -144,6 +144,7 @@ def calc_V(x, n):
 
 @lru_cache(maxsize=None)
 def _coefficients():
+    """Compute the coefficients on demand, in order to avoid doing linear algebra on import."""
     eps = np.spacing(1)
 
     # the nodes and Newton polynomials

--- a/adaptive/learner/integrator_coeffs.py
+++ b/adaptive/learner/integrator_coeffs.py
@@ -1,11 +1,15 @@
 # Based on an adaptive quadrature algorithm by Pedro Gonnet
 
-import functools
 from collections import defaultdict
 from fractions import Fraction
 
 import numpy as np
 import scipy.linalg
+
+try:
+    from functools import cached_property
+except ImportError:
+    from adaptive.utils import cached_property
 
 
 def legendre(n):
@@ -140,10 +144,6 @@ def calc_V(x, n):
     for i in range(n):
         V[i] *= np.sqrt(i + 0.5)
     return np.array(V).T
-
-
-def cached_property(f):
-    return property(functools.lru_cache(None)(f))
 
 
 class Coefficients:

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -10,13 +10,10 @@ import numpy as np
 from scipy.linalg import norm
 from sortedcontainers import SortedSet
 
+import adaptive.learner.integrator_coeffs as coeff
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.utils import cache_latest, restore
-
-from .integrator_coeffs import Coefficients
-
-coeff = Coefficients()
 
 
 def _downdate(c, nans, depth):

--- a/adaptive/tests/test_cquad.py
+++ b/adaptive/tests/test_cquad.py
@@ -5,13 +5,15 @@ import numpy as np
 import pytest
 
 from adaptive.learner import IntegratorLearner
-from adaptive.learner.integrator_coeffs import ns
+from adaptive.learner.integrator_coeffs import Coefficients
 from adaptive.learner.integrator_learner import DivergentIntegralError
 
 from .algorithm_4 import DivergentIntegralError as A4DivergentIntegralError
 from .algorithm_4 import algorithm_4, f0, f7, f21, f24, f63, fdiv
 
 eps = np.spacing(1)
+
+ns = Coefficients().ns
 
 
 def run_integrator_learner(f, a, b, tol, n):

--- a/adaptive/tests/test_cquad.py
+++ b/adaptive/tests/test_cquad.py
@@ -4,16 +4,14 @@ from operator import attrgetter
 import numpy as np
 import pytest
 
+import adaptive.learner.integrator_coeffs as coeff
 from adaptive.learner import IntegratorLearner
-from adaptive.learner.integrator_coeffs import Coefficients
 from adaptive.learner.integrator_learner import DivergentIntegralError
 
 from .algorithm_4 import DivergentIntegralError as A4DivergentIntegralError
 from .algorithm_4 import algorithm_4, f0, f7, f21, f24, f63, fdiv
 
 eps = np.spacing(1)
-
-ns = Coefficients().ns
 
 
 def run_integrator_learner(f, a, b, tol, n):
@@ -247,7 +245,7 @@ def test_removed_choose_mutiple_points_at_once():
     we should use the high-precision interval.
     """
     learner = IntegratorLearner(np.exp, bounds=(0, 1), tol=1e-15)
-    n = ns[-1] + 2 * (ns[0] - 2)  # first + two children (33+6=39)
+    n = coeff.ns[-1] + 2 * (coeff.ns[0] - 2)  # first + two children (33+6=39)
     xs, _ = learner.ask(n)
     for x in xs:
         learner.tell(x, learner.function(x))
@@ -259,7 +257,7 @@ def test_removed_ask_one_by_one():
         # This test should raise because integrating np.exp should be done
         # after the 33th point
         learner = IntegratorLearner(np.exp, bounds=(0, 1), tol=1e-15)
-        n = ns[-1] + 2 * (ns[0] - 2)  # first + two children (33+6=39)
+        n = coeff.ns[-1] + 2 * (coeff.ns[0] - 2)  # first + two children (33+6=39)
         for _ in range(n):
             xs, _ = learner.ask(1)
             for x in xs:

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -83,3 +83,7 @@ class _RequireAttrsABCMeta(abc.ABCMeta):
                     msg = f"The attribute '{name}' should be of type {type_}, not {type(x)}."
                     raise TypeError(msg)
         return obj
+
+
+def cached_property(f):
+    return property(functools.lru_cache(None)(f))

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -83,7 +83,3 @@ class _RequireAttrsABCMeta(abc.ABCMeta):
                     msg = f"The attribute '{name}' should be of type {type_}, not {type(x)}."
                     raise TypeError(msg)
         return obj
-
-
-def cached_property(f):
-    return property(functools.lru_cache(None)(f))


### PR DESCRIPTION
## Description

Currently, the having the following in a script:
```
import adaptive
import gpytorch
```
breaks any Python process because of https://github.com/pytorch/pytorch/issues/54063.

This is not a proper fix but avoiding the problem. 

Howver, rather than doing any math on import, I think it is a better style to only evaluate the coefficients when required.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] (Code) style fix or documentation update
- [ ] This change requires a documentation update
