### PR TITLE
bump to Python≥3.7

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,15 +13,15 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.10.0
+  rev: v2.11.0
   hooks:
   - id: pyupgrade
-    args: ['--py36-plus']
+    args: ['--py37-plus']
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.7.0
+  rev: 5.8.0
   hooks:
   - id: isort
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+  rev: 3.9.0
   hooks:
   - id: flake8

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Adaptively learning a 1D function (the `gif` below) and live-plotting the proces
 Installation
 ------------
 
-``adaptive`` works with Python 3.6 and higher on Linux, Windows, or Mac,
+``adaptive`` works with Python 3.7 and higher on Linux, Windows, or Mac,
 and provides optional extensions for working with the Jupyter/IPython
 Notebook.
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -7,7 +7,7 @@
     "environment_type": "conda",
     "install_timeout": 600,
     "show_commit_url": "https://github.com/python-adaptive/adaptive/commits/",
-    "pythons": ["3.6"],
+    "pythons": ["3.7"],
     "conda_channels": ["conda-forge"],
     "matrix": {
         "numpy": ["1.13"],

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 - conda-forge
 
 dependencies:
-  - python=3.6
+  - python=3.7
   - sortedcontainers
   - sortedcollections
   - scipy

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ import sys
 
 from setuptools import find_packages, setup
 
-if sys.version_info < (3, 6):
-    print("adaptive requires Python 3.6 or above.")
+if sys.version_info < (3, 7):
+    print("adaptive requires Python 3.7 or above.")
     sys.exit(1)
 
 
@@ -65,7 +65,7 @@ setup(
     name="adaptive",
     description="Parallel active learning of mathematical functions",
     version=version,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     url="https://adaptive.readthedocs.io/",
     author="Adaptive authors",
     license="BSD",
@@ -73,9 +73,9 @@ setup(
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: BSD License",
         "Intended Audience :: Science/Research",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     packages=find_packages("."),
     install_requires=install_requires,


### PR DESCRIPTION
## Description

Let's stick with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#support-table) and drop Python 3.6 support.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [x] This change requires a documentation update
