### PR TITLE
raise an AttributeError when attribute doesn't exists, closes #314

### DIFF
--- a/adaptive/learner/integrator_coeffs.py
+++ b/adaptive/learner/integrator_coeffs.py
@@ -186,5 +186,8 @@ def _coefficients():
     return locals()
 
 
-def __getattr__(attr):
-    return _coefficients()[attr]
+def __getattr__(name):
+    try:
+        return _coefficients()[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Description

We should raise an `AttributeError` as is appropriate when an attribute isn't found.

Fixes #314

@akhmerov, if you would give this your blessing?

@caenrigen, this should fix you issue.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
