### PR TITLE
call self._process_futures on canceled futures when BlockingRunner is done

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -412,7 +412,10 @@ class BlockingRunner(BaseRunner):
             remaining = self._remove_unfinished()
             if remaining:
                 concurrent.wait(remaining)
-                self._process_futures(remaining)
+                # Some futures get their result set, despite being cancelled.
+                # see https://github.com/python-adaptive/adaptive/issues/319
+                with_result = [f for f in remaining if not f.cancelled() and f.done()]
+                self._process_futures(with_result)
             self._cleanup()
 
     def elapsed_time(self):

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -412,6 +412,7 @@ class BlockingRunner(BaseRunner):
             remaining = self._remove_unfinished()
             if remaining:
                 concurrent.wait(remaining)
+                self._process_futures(remaining)
             self._cleanup()
 
     def elapsed_time(self):


### PR DESCRIPTION
## Description

call self._process_futures on canceled futures when BlockingRunner is done.

thanks @jgukelberger for noticing this

Fixes #319

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
