### PR TITLE
Update doc string for resolution_loss_function

### DIFF
--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -96,7 +96,7 @@ def resolution_loss_function(min_length=0, max_length=1):
     ...     return x**2
     >>>
     >>> loss = resolution_loss_function(min_length=0.01, max_length=1)
-    >>> learner = adaptive.Learner1D(f, bounds=[(-1, -1), (1, 1)], loss_per_triangle=loss)
+    >>> learner = adaptive.Learner1D(f, bounds=(-1, -1), loss_per_interval=loss)
     """
 
     @uses_nth_neighbors(0)


### PR DESCRIPTION
## Description

A tiny correction to the doc string, as discussed in #322.

Fixes #322

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed:
^ this did not pass (but I haven't modified anything other than the doc string), here's what I get:
```pytb
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov --cov-append --cov-fail-under=70 --cov-report=
  inifile: /Users/me/adaptive/tox.ini
  rootdir: /Users/me/adaptive
```

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] (Code) style fix or documentation update
- [ ] This change requires a documentation update
