### PR TITLE
use jupyter-sphinx instead of custom Sphinx directive

### DIFF
--- a/docs/logo_animated.py
+++ b/docs/logo_animated.py
@@ -1,3 +1,5 @@
+import os
+
 import matplotlib.tri as mtri
 import numpy as np
 from matplotlib import animation
@@ -96,4 +98,6 @@ def main(fname="source/_static/logo_docs.mp4"):
 
 
 if __name__ == "__main__":
-    main()
+    fname = "_static/logo_docs.mp4"
+    if not os.path.exists(fname):
+        main(fname)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,9 +14,6 @@
 import os
 import sys
 
-from docutils import nodes
-from docutils.parsers.rst import Directive
-
 package_path = os.path.abspath("../..")
 # Insert into sys.path so that we can import adaptive here
 sys.path.insert(0, package_path)
@@ -160,20 +157,5 @@ html_js_files = [
 html_logo = "_static/logo_docs.png"
 
 
-class RunLogoAnimated(Directive):
-    def run(self):
-        fname = "_static/logo_docs.mp4"
-        if not os.path.exists(fname):
-            import logo_animated
-
-            print(f"{fname} does not exist.")
-            logo_animated.main(fname)
-        style = "width: 400px; max-width: 100%; margin: 0 auto; display:block;"
-        opts = f'autoplay loop muted playsinline webkit-playsinline style="{style}"'
-        html = f'<video {opts}><source src="{fname}" type="video/mp4"></video><br>'
-        return [nodes.raw(text=html, format="html")]
-
-
 def setup(app):
     app.add_css_file("custom.css")  # For the `live_info` widget
-    app.add_directive("animated-logo", RunLogoAnimated)

--- a/docs/source/logo.rst
+++ b/docs/source/logo.rst
@@ -1,1 +1,10 @@
-.. animated-logo::
+.. jupyter-execute:: ../logo_animated.py
+    :hide-code:
+    :hide-output:
+
+.. raw:: html
+
+    <video autoplay loop muted playsinline webkit-playsinline
+     style="width: 400px; max-width: 100%; margin: 0 auto; display:block;">
+      <source src="_static/logo_docs.mp4" type="video/mp4">
+    </video><br>


### PR DESCRIPTION
## Description

@akhmerov, it turned out that Github didn't properly hide the custom directive, so I had to `.. include::` a file with the `.. animated-logo::` directive.

So instead of having two levels of abstraction, now we only have one.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] (Code) style fix or documentation update
- [ ] This change requires a documentation update
