### PR TITLE
Fix NaN issue for Learner1D R -> R^n

### DIFF
--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -464,8 +464,8 @@ class Learner1D(BaseLearner):
         if y is not None:
             if self.vdim > 1:
                 try:
-                    y_min = np.min([self._bbox[1][0], y], axis=0)
-                    y_max = np.max([self._bbox[1][1], y], axis=0)
+                    y_min = np.nanmin([self._bbox[1][0], y], axis=0)
+                    y_max = np.nanmax([self._bbox[1][1], y], axis=0)
                 except ValueError:
                     # Happens when `_bbox[1]` is a float and `y` a vector.
                     y_min = y_max = y


### PR DESCRIPTION
## Description

If a function evaluates over a point where it is not defined, NaN will be returned.
In the case of a function R -> R^n, it caused `_update_scale` to compute `self._scale[1] = nan`,
which in turns led to the evaluation of the function on all other points to be NaN, causing an
infinite loop, as reported in issue #339.

Using `np.nanmin` and `np.nanmax` in place of `np.min` and `np.max` seems to solve the issue.

Fixes  #339

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
