### PR TITLE
Fix class name issue with modern versions of dask.distributed

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -806,7 +806,9 @@ def _ensure_executor(executor):
         return executor
     elif with_ipyparallel and isinstance(executor, ipyparallel.Client):
         return executor.executor()
-    elif with_distributed and isinstance(executor, distributed.Client):
+    elif with_distributed and isinstance(
+        executor, (distributed.Client, distributed.client.Client)
+    ):
         return executor.get_executor()
     else:
         raise TypeError(


### PR DESCRIPTION
## Description
Fixes a class name error when using a modern version of distributed with adaptive.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
