### PR TITLE
Add transparent logo in WebM format (for dark mode)

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - myst-nb=0.16.0
   - sphinx_fontawesome=0.0.6
   - sphinx=4.2.0
-  - ffmpeg=4.3.2
+  - ffmpeg=5.1.1
   - cloudpickle
   - loky
   - furo

--- a/docs/source/algorithms_and_examples.md
+++ b/docs/source/algorithms_and_examples.md
@@ -111,7 +111,7 @@ def get_hm(loss_per_interval, N=101):
     plots = {n: plot(learner, n) for n in range(N)}
     return hv.HoloMap(plots, kdims=["npoints"])
 
-plot_homo = get_hm(uniform_loss).relabel("homogeneous samping")
+plot_homo = get_hm(uniform_loss).relabel("homogeneous sampling")
 plot_adaptive = get_hm(default_loss).relabel("with adaptive")
 layout = plot_homo + plot_adaptive
 layout.opts(plot=dict(toolbar=None))

--- a/docs/source/logo.md
+++ b/docs/source/logo.md
@@ -134,7 +134,7 @@ def setup(nseconds=15):
     return npoints, learner, data, rounded_corners, fig, ax
 
 
-def animate_mp4(fname="source/_static/logo_docs.mp4"):
+def animate_mp4(fname="source/_static/logo_docs.mp4", nseconds=15):
     npoints, learner, data, rounded_corners, fig, ax = setup()
     artists = [
         get_new_artists(n, learner, data, rounded_corners, ax) for n in tqdm(npoints)
@@ -143,36 +143,40 @@ def animate_mp4(fname="source/_static/logo_docs.mp4"):
     ani.save(fname, writer=FFMpegWriter(fps=24))
 
 
-def animate_png(folder="source/_static/logo", nseconds=2):
+def animate_png(folder="/tmp", nseconds=15):
     npoints, learner, data, rounded_corners, fig, ax = setup(nseconds)
     folder = Path(folder)
     folder.mkdir(parents=True, exist_ok=True)
     fnames = []
+    ims = []
     for n in tqdm(npoints):
         fname = folder / f"logo_docs_{n:03d}.png"
         fnames.append(fname)
-        npoints, learner, data, _, fig, ax = setup(nseconds=2)
+        npoints, learner, data, _, fig, ax = setup(nseconds)
         get_new_artists(n, learner, data, None, ax)
         fig.savefig(fname, transparent=True)
         ax.cla()
-        remove_rounded_corners(fname)
-    return fnames
+        plt.close(fig)
+        im = remove_rounded_corners(fname)
+        ims.append(im)
+    return fnames, ims
 
 
 if __name__ == "__main__":
-    fname = Path("_static/logo_docs.mp4")
-    # if not fname.exists():
-    # ar = animate_mp4(fname)
-    animate_png()
-```
-
-```{code-cell} ipython3
-n = 10
-folder = Path("source/_static/logo")
-fname = folder / f"logo_docs_{n:03d}.png"
-npoints, learner, data, rounded_corners, fig, ax = setup(nseconds=2)
-get_new_artists(n, learner, data, None, ax)
-fig.savefig(fname, transparent=True)
+    fname_mp4 = Path("_static/logo_docs.mp4")
+    if not fname_mp4.exists():
+        animate_mp4(fname_mp4)
+    fname_webp = fname_mp4.with_suffix(".webp")
+    if not fname_webp.exists():
+        fnames, ims = animate_png()
+        im.save(
+            fname_webp,
+            save_all=True,
+            append_images=_ims,
+            opimize=False,
+            durarion=2,
+            quality=70,
+        )
 ```
 
 ```{eval-rst}

--- a/docs/source/logo.md
+++ b/docs/source/logo.md
@@ -191,6 +191,8 @@ def save_webm(fname, fnames):
         "libvpx-vp9",
         "-pix_fmt",
         "yuva420p",
+        "-crf",
+        "23",  # 0 is lossless 51 is worst
         "-y",
         fname,
     ]

--- a/docs/source/logo.md
+++ b/docs/source/logo.md
@@ -17,6 +17,7 @@ kernelspec:
 import os
 import functools
 import subprocess
+import tempfile
 from pathlib import Path
 
 import matplotlib.tri as mtri
@@ -141,7 +142,7 @@ def animate_mp4(fname="source/_static/logo_docs.mp4", nseconds=15):
         get_new_artists(n, learner, data, rounded_corners, ax) for n in tqdm(npoints)
     ]
     ani = animation.ArtistAnimation(fig, artists, blit=True)
-    ani.save(fname, writer=FFMpegWriter(fps=24, codec="libvpx-vp9"))
+    ani.save(fname, writer=FFMpegWriter(fps=24))
 
 
 def animate_png(folder=None, nseconds=15):

--- a/docs/source/logo.md
+++ b/docs/source/logo.md
@@ -201,7 +201,7 @@ if __name__ == "__main__":
     # if not fname_mp4.exists():
     #     animate_mp4(fname_mp4)
     fname_webm = fname_mp4.with_suffix(".webm")
-    if not fname_webp.exists():
+    if not fname_webm.exists():
         fnames, ims = animate_png()
         save_webm(fname_webm, fnames)
 ```


### PR DESCRIPTION
## Description

Makes the contour around the animated logo transparent.

Currently it looks like:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/6897215/188499620-13133da0-a674-4421-be50-baed83774e38.png">


## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] (Code) style fix or documentation update
- [ ] This change requires a documentation update
