### PR TITLE
Fix HoloViews opts deprecation warnings

### DIFF
--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -818,12 +818,9 @@ class Learner2D(BaseLearner):
         else:
             im = hv.Image([], bounds=lbrt)
             tris = hv.EdgePaths([])
-
-        im_opts = {"cmap": "viridis"}
-        tri_opts = {"line_width": 0.5, "alpha": tri_alpha}
-        no_hover = {"plot": {"inspection_policy": None, "tools": []}}
-
-        return im.opts(style=im_opts) * tris.opts(style=tri_opts, **no_hover)
+        return im.opts(cmap="viridis") * tris.opts(
+            line_width=0.5, alpha=tri_alpha, tools=[]
+        )
 
     def _get_data(self) -> dict[tuple[float, float], Float | np.ndarray]:
         return self.data

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -932,12 +932,9 @@ class LearnerND(BaseLearner):
         else:
             im = hv.Image([], bounds=lbrt)
             tris = hv.EdgePaths([])
-
-        im_opts = {"cmap": "viridis"}
-        tri_opts = {"line_width": 0.5, "alpha": tri_alpha}
-        no_hover = {"plot": {"inspection_policy": None, "tools": []}}
-
-        return im.opts(style=im_opts) * tris.opts(style=tri_opts, **no_hover)
+        return im.opts(cmap="viridis") * tris.opts(
+            line_width=0.5, alpha=tri_alpha, tools=[]
+        )
 
     def plot_slice(self, cut_mapping, n=None):
         """Plot a 1D or 2D interpolated slice of a N-dimensional function.
@@ -1005,7 +1002,7 @@ class LearnerND(BaseLearner):
             else:
                 im = hv.Image([], bounds=lbrt)
 
-            return im.opts(style={"cmap": "viridis"})
+            return im.opts(cmap="viridis")
         else:
             raise ValueError("Only 1 or 2-dimensional plots can be generated.")
 
@@ -1199,10 +1196,7 @@ class LearnerND(BaseLearner):
 
         vertices, lines = self._get_iso(level, which="line")
         paths = [[vertices[i], vertices[j]] for i, j in lines]
-        contour = hv.Path(paths)
-
-        contour_opts = {"color": "black"}
-        contour = contour.opts(style=contour_opts)
+        contour = hv.Path(paths).opts(color="black")
         return plot * contour
 
     def plot_isosurface(self, level=0.0, hull_opacity=0.2):

--- a/adaptive/learner/skopt_learner.py
+++ b/adaptive/learner/skopt_learner.py
@@ -98,12 +98,12 @@ class SKOptLearner(Optimizer, BaseLearner):
                 xsp = self.space.transform(xs.reshape(-1, 1).tolist())
                 y_pred, sigma = model.predict(xsp, return_std=True)
                 # Plot model prediction for function
-                curve = hv.Curve((xs, y_pred)).opts(style={"line_dash": "dashed"})
+                curve = hv.Curve((xs, y_pred)).opts(line_dash="dashed")
                 # Plot 95% confidence interval as colored area around points
                 area = hv.Area(
                     (xs, y_pred - 1.96 * sigma, y_pred + 1.96 * sigma),
                     vdims=["y", "y2"],
-                ).opts(style={"alpha": 0.5, "line_alpha": 0})
+                ).opts(alpha=0.5, line_alpha=0)
 
             else:
                 area = hv.Area([])

--- a/docs/source/algorithms_and_examples.md
+++ b/docs/source/algorithms_and_examples.md
@@ -98,7 +98,7 @@ def plot_loss_interval(learner):
         x, y = [x_0, x_1], [y_0, y_1]
     else:
         x, y = [], []
-    return hv.Scatter((x, y)).opts(style=dict(size=6, color="r"))
+    return hv.Scatter((x, y)).opts(size=6, color="r")
 
 
 def plot(learner, npoints):
@@ -114,7 +114,7 @@ def get_hm(loss_per_interval, N=101):
 plot_homo = get_hm(uniform_loss).relabel("homogeneous sampling")
 plot_adaptive = get_hm(default_loss).relabel("with adaptive")
 layout = plot_homo + plot_adaptive
-layout.opts(plot=dict(toolbar=None))
+layout.opts(toolbar=None)
 ```
 
 ## {class}`adaptive.Learner2D`

--- a/docs/source/tutorial/tutorial.LearnerND.md
+++ b/docs/source/tutorial/tutorial.LearnerND.md
@@ -94,7 +94,7 @@ dm = dm.redim.values(
 
 # In a notebook one would run `dm` however we want a statically generated
 # html, so we use a HoloMap to display it here
-dynamicmap_to_holomap(dm).options(hv.opts.Path(framewise=True))
+dynamicmap_to_holomap(dm).opts(hv.opts.Path(framewise=True))
 ```
 
 The plots show some wobbles while the original function was smooth, this is a result of the fact that the learner chooses points in 3 dimensions and the simplices are not in the same face as we try to interpolate our lines.

--- a/docs/source/tutorial/tutorial.advanced-topics.md
+++ b/docs/source/tutorial/tutorial.advanced-topics.md
@@ -316,7 +316,7 @@ adaptive.runner.replay_log(reconstructed_learner, runner.log)
 ```
 
 ```{code-cell} ipython3
-learner.plot().Scatter.I.opts(style=dict(size=6)) * reconstructed_learner.plot()
+learner.plot().Scatter.I.opts(size=6) * reconstructed_learner.plot()
 ```
 
 ## Adding coroutines

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[flake8]
-max-line-length = 100
-ignore = E501, W503, E203, E266, E741
-max-complexity = 18
-select = B, C, E, F, W, T4, B9
-exclude = .git, .tox, __pycache__, dist, .nox


### PR DESCRIPTION
WARNING:param.main: Calling the .opts method with options broken down by options group (i.e. separate plot, style and norm groups) is deprecated. Use the .options method converting to the simplified format instead or use hv.opts.apply_groups for backward compatibility.

## Description

Please include a summary of the change and which (if so) issue is fixed.

Fixes #(ISSUE_NUMBER_HERE)

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
