### PR TITLE
Add getting learner's data as pandas.DataFrame; add learner.to_dataframe method

### DIFF
--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -9,7 +9,7 @@ import numpy as np
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.types import Float, Real
-from adaptive.utils import cache_latest, default_parameters
+from adaptive.utils import assign_defaults, cache_latest
 
 try:
     import pandas
@@ -89,8 +89,7 @@ class AverageLearner(BaseLearner):
             raise ImportError("pandas is not installed.")
         df = pandas.DataFrame(sorted(self.data.items()), columns=[seed_name, y_name])
         if with_default_function_args:
-            defaults = default_parameters(self.function, function_prefix)
-            df = df.assign(**defaults)
+            assign_defaults(self.function, df, function_prefix)
         return df
 
     def ask(self, n: int, tell_pending: bool = True) -> tuple[list[int], list[Float]]:

--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -128,6 +128,26 @@ class AverageLearner(BaseLearner):
         seed_name: str = "seed",
         y_name: str = "y",
     ):
+        """Load data from a `pandas.DataFrame`.
+
+        If ``with_default_function_args`` is True, then ``learner.function``'s
+        default arguments are set (using `functools.partial`) from the values
+        in the `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The data to load.
+        with_default_function_args : bool, optional
+            The ``with_default_function_args`` used in ``to_dataframe()``,
+            by default True
+        function_prefix : str, optional
+            The ``function_prefix`` used in ``to_dataframe``, by default "function."
+        seed_name : str, optional
+            The ``seed_name`` used in ``to_dataframe``, by default "seed"
+        y_name : str, optional
+            The ``y_name`` used in ``to_dataframe``, by default "y"
+        """
         self.tell_many(df[seed_name].values, df[y_name].values)
         if with_default_function_args:
             self.function = partial_function_from_dataframe(

--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.notebook_integration import ensure_holoviews
-from adaptive.types import Float, Real
+from adaptive.types import Float, Int, Real
 from adaptive.utils import (
     assign_defaults,
     cache_latest,
@@ -127,7 +127,7 @@ class AverageLearner(BaseLearner):
                 self.tell_pending(p)
         return points, loss_improvements
 
-    def tell(self, n: int, value: Real) -> None:
+    def tell(self, n: Int, value: Real) -> None:
         if n in self.data:
             # The point has already been added before.
             return

--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -89,6 +89,30 @@ class AverageLearner(BaseLearner):
         seed_name: str = "seed",
         y_name: str = "y",
     ) -> pandas.DataFrame:
+        """Return the data as a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        with_default_function_args : bool, optional
+            Include the ``learner.function``'s default arguments as a
+            column, by default True
+        function_prefix : str, optional
+            Prefix to the ``learner.function``'s default arguments' names,
+            by default "function."
+        seed_name : str, optional
+            Name of the ``seed`` parameter, by default "seed"
+        y_name : str, optional
+            Name of the output value, by default "y"
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         df = pandas.DataFrame(sorted(self.data.items()), columns=[seed_name, y_name])

--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -98,7 +98,7 @@ class AverageLearner(BaseLearner):
 
     def load_dataframe(
         self,
-        df,
+        df: pandas.DataFrame,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         seed_name: str = "seed",

--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -116,6 +116,8 @@ class AverageLearner(BaseLearner):
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         df = pandas.DataFrame(sorted(self.data.items()), columns=[seed_name, y_name])
+        df.attrs["inputs"] = [seed_name]
+        df.attrs["output"] = y_name
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -9,7 +9,11 @@ import numpy as np
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.types import Float, Real
-from adaptive.utils import assign_defaults, cache_latest
+from adaptive.utils import (
+    assign_defaults,
+    cache_latest,
+    partial_function_from_dataframe,
+)
 
 try:
     import pandas
@@ -91,6 +95,20 @@ class AverageLearner(BaseLearner):
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df
+
+    def load_dataframe(
+        self,
+        df,
+        with_default_function_args: bool = True,
+        function_prefix: str = "function.",
+        seed_name: str = "seed",
+        y_name: str = "y",
+    ):
+        self.tell_many(df[seed_name].values, df[y_name].values)
+        if with_default_function_args:
+            self.function = partial_function_from_dataframe(
+                self.function, df, function_prefix
+            )
 
     def ask(self, n: int, tell_pending: bool = True) -> tuple[list[int], list[Float]]:
         points = list(range(self.n_requested, self.n_requested + n))

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -176,7 +176,7 @@ class AverageLearner1D(Learner1D):
 
     def load_dataframe(
         self,
-        df,
+        df: pandas.DataFrame,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         seed_name: str = "seed",

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -209,6 +209,28 @@ class AverageLearner1D(Learner1D):
         x_name: str = "x",
         y_name: str = "y",
     ):
+        """Load data from a `pandas.DataFrame`.
+
+        If ``with_default_function_args`` is True, then ``learner.function``'s
+        default arguments are set (using `functools.partial`) from the values
+        in the `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The data to load.
+        with_default_function_args : bool, optional
+            The ``with_default_function_args`` used in ``to_dataframe()``,
+            by default True
+        function_prefix : str, optional
+            The ``function_prefix`` used in ``to_dataframe``, by default "function."
+        seed_name : str, optional
+            The ``seed_name`` used in ``to_dataframe``, by default "seed"
+        x_name : str, optional
+            The ``x_name`` used in ``to_dataframe``, by default "x"
+        y_name : str, optional
+            The ``y_name`` used in ``to_dataframe``, by default "y"
+        """
         # Were using zip instead of df[[seed_name, x_name]].values because that will
         # make the seeds into floats
         seed_x = list(zip(df[seed_name].values.tolist(), df[x_name].values.tolist()))

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -196,6 +196,8 @@ class AverageLearner1D(Learner1D):
             ]
             columns = [seed_name, x_name, y_name]
         df = pandas.DataFrame(data, columns=columns)
+        df.attrs["inputs"] = [seed_name, x_name]
+        df.attrs["output"] = y_name
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -15,7 +15,7 @@ from sortedcontainers import SortedDict
 from adaptive.learner.learner1D import Learner1D, _get_intervals
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.types import Real
-from adaptive.utils import assign_defaults
+from adaptive.utils import assign_defaults, partial_function_from_dataframe
 
 try:
     import pandas
@@ -173,6 +173,21 @@ class AverageLearner1D(Learner1D):
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df
+
+    def load_dataframe(
+        self,
+        df,
+        with_default_function_args: bool = True,
+        function_prefix: str = "function.",
+        seed_name: str = "seed",
+        x_name: str = "x",
+        y_name: str = "y",
+    ):
+        self.tell_many(df[[seed_name, x_name]].values, df[y_name].values)
+        if with_default_function_args:
+            self.function = partial_function_from_dataframe(
+                self.function, df, function_prefix
+            )
 
     def ask(self, n: int, tell_pending: bool = True) -> tuple[Points, list[float]]:
         """Return 'n' points that are expected to maximally reduce the loss."""

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -15,7 +15,7 @@ from sortedcontainers import SortedDict
 from adaptive.learner.learner1D import Learner1D, _get_intervals
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.types import Real
-from adaptive.utils import default_parameters
+from adaptive.utils import assign_defaults
 
 try:
     import pandas
@@ -171,8 +171,7 @@ class AverageLearner1D(Learner1D):
             columns = [seed_name, x_name, y_name]
         df = pandas.DataFrame(data, columns=columns)
         if with_default_function_args:
-            defaults = default_parameters(self.function, function_prefix)
-            df = df.assign(**defaults)
+            assign_defaults(self.function, df, function_prefix)
         return df
 
     def ask(self, n: int, tell_pending: bool = True) -> tuple[Points, list[float]]:

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -150,7 +150,7 @@ class AverageLearner1D(Learner1D):
 
     def to_dataframe(
         self,
-        mean: bool = True,
+        mean: bool = False,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         seed_name: str = "seed",

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -157,6 +157,32 @@ class AverageLearner1D(Learner1D):
         x_name: str = "x",
         y_name: str = "y",
     ) -> pandas.DataFrame:
+        """Return the data as a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        with_default_function_args : bool, optional
+            Include the ``learner.function``'s default arguments as a
+            column, by default True
+        function_prefix : str, optional
+            Prefix to the ``learner.function``'s default arguments' names,
+            by default "function."
+        seed_name : str, optional
+            Name of the ``seed`` parameter, by default "seed"
+        x_name : str, optional
+            Name of the ``x`` parameter, by default "x"
+        y_name : str, optional
+            Name of the output value, by default "y"
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         if mean:

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -136,7 +136,7 @@ class AverageLearner1D(Learner1D):
             return 0
         return min(self._number_samples.values())
 
-    def to_numpy(self, mean: bool = True) -> np.ndarray:
+    def to_numpy(self, mean: bool = False) -> np.ndarray:
         if mean:
             return super().to_numpy()
         else:

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -11,6 +11,14 @@ from adaptive.learner.base_learner import BaseLearner
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.utils import cache_latest, named_product, restore
 
+try:
+    import pandas
+
+    with_pandas = True
+
+except ModuleNotFoundError:
+    with_pandas = False
+
 
 def dispatch(child_functions, arg):
     index, x = arg
@@ -380,6 +388,13 @@ class BalancingLearner(BaseLearner):
             learner = learner_type(function=partial(f, **combo), **learner_kwargs)
             learners.append(learner)
         return cls(learners, cdims=arguments)
+
+    def to_dataframe(self, kwargs):
+        if not with_pandas:
+            raise ImportError("pandas is not installed.")
+        dfs = [learner.to_dataframe(**kwargs) for learner in self.learners]
+        df = pandas.concat(dfs, axis=0, ignore_index=True)
+        return df
 
     def save(self, fname, compress=True):
         """Save the data of the child learners into pickle files

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -389,7 +389,7 @@ class BalancingLearner(BaseLearner):
             learners.append(learner)
         return cls(learners, cdims=arguments)
 
-    def to_dataframe(self, kwargs):
+    def to_dataframe(self, **kwargs):
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         dfs = [learner.to_dataframe(**kwargs) for learner in self.learners]

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -390,6 +390,22 @@ class BalancingLearner(BaseLearner):
         return cls(learners, cdims=arguments)
 
     def to_dataframe(self, **kwargs):
+        """Return the data as a concatenated `pandas.DataFrame` from child learners.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Keyword arguments passed to each ``child_learner.to_dataframe(**kwargs)``.
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         dfs = [learner.to_dataframe(**kwargs) for learner in self.learners]

--- a/adaptive/learner/data_saver.py
+++ b/adaptive/learner/data_saver.py
@@ -87,7 +87,11 @@ class DataSaver:
         return df
 
     def load_dataframe(
-        self, df: pandas.DataFrame, extra_data_name: str = "extra_data", **kwargs
+        self,
+        df: pandas.DataFrame,
+        extra_data_name: str = "extra_data",
+        input_names: tuple[str] = (),
+        **kwargs
     ):
         """Load the data from a `pandas.DataFrame` into the learner.
 
@@ -97,11 +101,18 @@ class DataSaver:
             DataFrame with the data to load.
         extra_data_name : str, optional
             The ``extra_data_name`` used in `to_dataframe`, by default "extra_data".
+        input_names : tuple[str], optional
+            The input names of the child learner. By default the input names are
+            taken from ``df.attrs["inputs"]``, however, metadata is not preserved
+            when saving/loading a DataFrame to/from a file. In that case, the input
+            names can be passed explicitly. For example, for a 2D learner, this would
+            be ``input_names=('x', 'y')``.
         **kwargs : dict
             Keyword arguments passed to each ``child_learner.load_dataframe(**kwargs)``.
         """
         self.learner.load_dataframe(df, **kwargs)
-        for _, x in df[df.attrs["inputs"] + [extra_data_name]].iterrows():
+        keys = df.attrs.get("inputs", list(input_names))
+        for _, x in df[keys + [extra_data_name]].iterrows():
             key = _to_key(x[:-1])
             self.extra_data[key] = x[-1]
 

--- a/adaptive/learner/data_saver.py
+++ b/adaptive/learner/data_saver.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 from collections import OrderedDict
 
@@ -91,7 +93,7 @@ class DataSaver:
         df: pandas.DataFrame,
         extra_data_name: str = "extra_data",
         input_names: tuple[str] = (),
-        **kwargs
+        **kwargs,
     ):
         """Load the data from a `pandas.DataFrame` into the learner.
 

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -13,7 +13,7 @@ from sortedcontainers import SortedSet
 from adaptive.learner import integrator_coeffs as coeff
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.notebook_integration import ensure_holoviews
-from adaptive.utils import cache_latest, default_parameters, restore
+from adaptive.utils import assign_defaults, cache_latest, restore
 
 try:
     import pandas
@@ -569,8 +569,7 @@ class IntegratorLearner(BaseLearner):
             raise ImportError("pandas is not installed.")
         df = pandas.DataFrame(sorted(self.data.items()), columns=[x_name, y_name])
         if with_default_function_args:
-            defaults = default_parameters(self.function, function_prefix)
-            df = df.assign(**defaults)
+            assign_defaults(self.function, df, function_prefix)
         return df
 
     def _get_data(self):

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -594,6 +594,8 @@ class IntegratorLearner(BaseLearner):
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         df = pandas.DataFrame(sorted(self.data.items()), columns=[x_name, y_name])
+        df.attrs["inputs"] = [x_name]
+        df.attrs["output"] = y_name
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -565,6 +565,32 @@ class IntegratorLearner(BaseLearner):
         x_name: str = "x",
         y_name: str = "y",
     ) -> pandas.DataFrame:
+        """Return the data as a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        with_default_function_args : bool, optional
+            Include the ``learner.function``'s default arguments as a
+            column, by default True
+        function_prefix : str, optional
+            Prefix to the ``learner.function``'s default arguments' names,
+            by default "function."
+        seed_name : str, optional
+            Name of the seed parameter, by default "seed"
+        x_name : str, optional
+            Name of the input value, by default "x"
+        y_name : str, optional
+            Name of the output value, by default "y"
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         df = pandas.DataFrame(sorted(self.data.items()), columns=[x_name, y_name])

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -351,7 +351,7 @@ class Learner1D(BaseLearner):
 
     def load_dataframe(
         self,
-        df,
+        df: pandas.DataFrame,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         x_name: str = "x",

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -369,6 +369,8 @@ class Learner1D(BaseLearner):
         xs, ys = zip(*sorted(self.data.items())) if self.data else ([], [])
         df = pandas.DataFrame(xs, columns=[x_name])
         df[y_name] = ys
+        df.attrs["inputs"] = [x_name]
+        df.attrs["output"] = y_name
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -16,7 +16,7 @@ from adaptive.learner.learnerND import volume
 from adaptive.learner.triangulation import simplex_volume_in_embedding
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.types import Float, Int, Real
-from adaptive.utils import cache_latest, default_parameters
+from adaptive.utils import assign_defaults, cache_latest
 
 try:
     import pandas
@@ -338,10 +338,11 @@ class Learner1D(BaseLearner):
     ) -> pandas.DataFrame:
         if not with_pandas:
             raise ImportError("pandas is not installed.")
-        df = pandas.DataFrame(sorted(self.data.items()), columns=[x_name, y_name])
+        xs, ys = zip(*sorted(self.data.items())) if self.data else ([], [])
+        df = pandas.DataFrame(xs, columns=["x"])
+        df[y_name] = ys
         if with_default_function_args:
-            defaults = default_parameters(self.function, function_prefix)
-            df = df.assign(**defaults)
+            assign_defaults(self.function, df, function_prefix)
         return df
 
     @property

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -563,8 +563,11 @@ class Learner1D(BaseLearner):
 
     def tell_many(
         self,
-        xs: Sequence[Float],
-        ys: (Sequence[Float] | Sequence[Sequence[Float]] | Sequence[np.ndarray]),
+        xs: Sequence[Float] | np.ndarray,
+        ys: Sequence[Float]
+        | Sequence[Sequence[Float]]
+        | Sequence[np.ndarray]
+        | np.ndarray,
         *,
         force: bool = False,
     ) -> None:

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -340,6 +340,30 @@ class Learner1D(BaseLearner):
         x_name: str = "x",
         y_name: str = "y",
     ) -> pandas.DataFrame:
+        """Return the data as a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        with_default_function_args : bool, optional
+            Include the ``learner.function``'s default arguments as a
+            column, by default True
+        function_prefix : str, optional
+            Prefix to the ``learner.function``'s default arguments' names,
+            by default "function."
+        x_name : str, optional
+            Name of the input value, by default "x"
+        y_name : str, optional
+            Name of the output value, by default "y"
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         xs, ys = zip(*sorted(self.data.items())) if self.data else ([], [])

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -381,6 +381,26 @@ class Learner1D(BaseLearner):
         x_name: str = "x",
         y_name: str = "y",
     ):
+        """Load data from a `pandas.DataFrame`.
+
+        If ``with_default_function_args`` is True, then ``learner.function``'s
+        default arguments are set (using `functools.partial`) from the values
+        in the `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The data to load.
+        with_default_function_args : bool, optional
+            The ``with_default_function_args`` used in ``to_dataframe()``,
+            by default True
+        function_prefix : str, optional
+            The ``function_prefix`` used in ``to_dataframe``, by default "function."
+        x_name : str, optional
+            The ``x_name`` used in ``to_dataframe``, by default "x"
+        y_name : str, optional
+            The ``y_name`` used in ``to_dataframe``, by default "y"
+        """
         self.tell_many(df[x_name].values, df[y_name].values)
         if with_default_function_args:
             self.function = partial_function_from_dataframe(

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -16,7 +16,11 @@ from adaptive.learner.learnerND import volume
 from adaptive.learner.triangulation import simplex_volume_in_embedding
 from adaptive.notebook_integration import ensure_holoviews
 from adaptive.types import Float, Int, Real
-from adaptive.utils import assign_defaults, cache_latest
+from adaptive.utils import (
+    assign_defaults,
+    cache_latest,
+    partial_function_from_dataframe,
+)
 
 try:
     import pandas
@@ -339,11 +343,25 @@ class Learner1D(BaseLearner):
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         xs, ys = zip(*sorted(self.data.items())) if self.data else ([], [])
-        df = pandas.DataFrame(xs, columns=["x"])
+        df = pandas.DataFrame(xs, columns=[x_name])
         df[y_name] = ys
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df
+
+    def load_dataframe(
+        self,
+        df,
+        with_default_function_args: bool = True,
+        function_prefix: str = "function.",
+        x_name: str = "x",
+        y_name: str = "y",
+    ):
+        self.tell_many(df[x_name].values, df[y_name].values)
+        if with_default_function_args:
+            self.function = partial_function_from_dataframe(
+                self.function, df, function_prefix
+            )
 
     @property
     def npoints(self) -> int:

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -474,7 +474,8 @@ class Learner2D(BaseLearner):
         z_name : str, optional
             The ``z_name`` used in ``to_dataframe``, by default "z"
         """
-        self.tell_many(df[[x_name, y_name]].values, df[z_name].values)
+        data = df.set_index([x_name, y_name])[z_name].to_dict()
+        self._set_data(data)
         if with_default_function_args:
             self.function = partial_function_from_dataframe(
                 self.function, df, function_prefix

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -11,7 +11,11 @@ from scipy import interpolate
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.learner.triangulation import simplex_volume_in_embedding
 from adaptive.notebook_integration import ensure_holoviews
-from adaptive.utils import assign_defaults, cache_latest
+from adaptive.utils import (
+    assign_defaults,
+    cache_latest,
+    partial_function_from_dataframe,
+)
 
 try:
     import pandas
@@ -408,6 +412,21 @@ class Learner2D(BaseLearner):
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df
+
+    def load_dataframe(
+        self,
+        df,
+        with_default_function_args: bool = True,
+        function_prefix: str = "function.",
+        x_name: str = "x",
+        y_name: str = "y",
+        z_name: str = "z",
+    ):
+        self.tell_many(df[[x_name, y_name]].values, df[z_name].values)
+        if with_default_function_args:
+            self.function = partial_function_from_dataframe(
+                self.function, df, function_prefix
+            )
 
     def _scale(self, points):
         points = np.asarray(points, dtype=float)

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import warnings
 from collections import OrderedDict
@@ -415,7 +417,7 @@ class Learner2D(BaseLearner):
 
     def load_dataframe(
         self,
-        df,
+        df: pandas.DataFrame,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         x_name: str = "x",

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -407,6 +407,34 @@ class Learner2D(BaseLearner):
         y_name: str = "y",
         z_name: str = "z",
     ) -> pandas.DataFrame:
+        """Return the data as a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        with_default_function_args : bool, optional
+            Include the ``learner.function``'s default arguments as a
+            column, by default True
+        function_prefix : str, optional
+            Prefix to the ``learner.function``'s default arguments' names,
+            by default "function."
+        seed_name : str, optional
+            Name of the seed parameter, by default "seed"
+        x_name : str, optional
+            Name of the input x value, by default "x"
+        y_name : str, optional
+            Name of the input y value, by default "y"
+        z_name : str, optional
+            Name of the output value, by default "z"
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         data = sorted((x, y, z) for (x, y), z in self.data.items())

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -11,7 +11,7 @@ from scipy import interpolate
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.learner.triangulation import simplex_volume_in_embedding
 from adaptive.notebook_integration import ensure_holoviews
-from adaptive.utils import cache_latest, default_parameters
+from adaptive.utils import assign_defaults, cache_latest
 
 try:
     import pandas
@@ -406,8 +406,7 @@ class Learner2D(BaseLearner):
         data = sorted((x, y, z) for (x, y), z in self.data.items())
         df = pandas.DataFrame(data, columns=[x_name, y_name, z_name])
         if with_default_function_args:
-            defaults = default_parameters(self.function, function_prefix)
-            df = df.assign(**defaults)
+            assign_defaults(self.function, df, function_prefix)
         return df
 
     def _scale(self, points):

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -452,6 +452,28 @@ class Learner2D(BaseLearner):
         y_name: str = "y",
         z_name: str = "z",
     ):
+        """Load data from a `pandas.DataFrame`.
+
+        If ``with_default_function_args`` is True, then ``learner.function``'s
+        default arguments are set (using `functools.partial`) from the values
+        in the `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The data to load.
+        with_default_function_args : bool, optional
+            The ``with_default_function_args`` used in ``to_dataframe()``,
+            by default True
+        function_prefix : str, optional
+            The ``function_prefix`` used in ``to_dataframe``, by default "function."
+        x_name : str, optional
+            The ``x_name`` used in ``to_dataframe``, by default "x"
+        y_name : str, optional
+            The ``y_name`` used in ``to_dataframe``, by default "y"
+        z_name : str, optional
+            The ``z_name`` used in ``to_dataframe``, by default "z"
+        """
         self.tell_many(df[[x_name, y_name]].values, df[z_name].values)
         if with_default_function_args:
             self.function = partial_function_from_dataframe(

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -439,6 +439,7 @@ class Learner2D(BaseLearner):
             raise ImportError("pandas is not installed.")
         data = sorted((x, y, z) for (x, y), z in self.data.items())
         df = pandas.DataFrame(data, columns=[x_name, y_name, z_name])
+        df.attrs["inputs"] = [x_name, y_name]
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -440,6 +440,7 @@ class Learner2D(BaseLearner):
         data = sorted((x, y, z) for (x, y), z in self.data.items())
         df = pandas.DataFrame(data, columns=[x_name, y_name, z_name])
         df.attrs["inputs"] = [x_name, y_name]
+        df.attrs["output"] = z_name
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -21,7 +21,12 @@ from adaptive.learner.triangulation import (
     simplex_volume_in_embedding,
 )
 from adaptive.notebook_integration import ensure_holoviews, ensure_plotly
-from adaptive.utils import assign_defaults, cache_latest, restore
+from adaptive.utils import (
+    assign_defaults,
+    cache_latest,
+    partial_function_from_dataframe,
+    restore,
+)
 
 try:
     import pandas
@@ -417,6 +422,20 @@ class LearnerND(BaseLearner):
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df
+
+    def load_dataframe(
+        self,
+        df,
+        with_default_function_args: bool = True,
+        function_prefix: str = "function.",
+        point_names: tuple[str, ...] = ("x", "y", "z"),
+        value_name: str = "value",
+    ):
+        self.tell_many(df[list(point_names)].values, df[value_name].values)
+        if with_default_function_args:
+            self.function = partial_function_from_dataframe(
+                self.function, df, function_prefix
+            )
 
     @property
     def bounds_are_done(self):

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -456,6 +456,26 @@ class LearnerND(BaseLearner):
         point_names: tuple[str, ...] = ("x", "y", "z"),
         value_name: str = "value",
     ):
+        """Load data from a `pandas.DataFrame`.
+
+        If ``with_default_function_args`` is True, then ``learner.function``'s
+        default arguments are set (using `functools.partial`) from the values
+        in the `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The data to load.
+        with_default_function_args : bool, optional
+            The ``with_default_function_args`` used in ``to_dataframe()``,
+            by default True
+        function_prefix : str, optional
+            The ``function_prefix`` used in ``to_dataframe``, by default "function."
+        point_names : str, optional
+            The ``point_names`` used in ``to_dataframe``, by default ("x", "y", "z")
+        value_name : str, optional
+            The ``value_name`` used in ``to_dataframe``, by default "value"
+        """
         self.tell_many(df[list(point_names)].values, df[value_name].values)
         if with_default_function_args:
             self.function = partial_function_from_dataframe(

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -401,7 +401,7 @@ class LearnerND(BaseLearner):
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         point_names: tuple[str, ...] = ("x", "y", "z"),
-        value_name: str = "y",
+        value_name: str = "value",
     ) -> pandas.DataFrame:
         if not with_pandas:
             raise ImportError("pandas is not installed.")
@@ -410,7 +410,7 @@ class LearnerND(BaseLearner):
                 f"point_names ({point_names}) should have the"
                 f" same length as learner.ndims ({self.ndim})"
             )
-        data = sorted((*x, y) for x, y in self.data.items())
+        data = list((*x, y) for x, y in self.data.items())
         df = pandas.DataFrame(data, columns=[*point_names, value_name])
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -425,7 +425,7 @@ class LearnerND(BaseLearner):
 
     def load_dataframe(
         self,
-        df,
+        df: pandas.DataFrame,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         point_names: tuple[str, ...] = ("x", "y", "z"),

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -445,6 +445,7 @@ class LearnerND(BaseLearner):
         data = list((*x, y) for x, y in self.data.items())
         df = pandas.DataFrame(data, columns=[*point_names, value_name])
         df.attrs["inputs"] = list(point_names)
+        df.attrs["output"] = value_name
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -400,7 +400,7 @@ class LearnerND(BaseLearner):
         self,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
-        point_names: tuple[str] = ("x", "y", "z"),
+        point_names: tuple[str, ...] = ("x", "y", "z"),
         value_name: str = "y",
     ) -> pandas.DataFrame:
         if not with_pandas:

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import itertools
 import random

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -410,6 +410,31 @@ class LearnerND(BaseLearner):
         point_names: tuple[str, ...] = ("x", "y", "z"),
         value_name: str = "value",
     ) -> pandas.DataFrame:
+        """Return the data as a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        with_default_function_args : bool, optional
+            Include the ``learner.function``'s default arguments as a
+            column, by default True
+        function_prefix : str, optional
+            Prefix to the ``learner.function``'s default arguments' names,
+            by default "function."
+        point_names : tuple[str, ...], optional
+            Names of the input points, should be the same length as number
+            of input parameters by default ("x", "y", "z" )
+        value_name : str, optional
+            Name of the output value, by default "value"
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         if len(point_names) != self.ndim:

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -444,6 +444,7 @@ class LearnerND(BaseLearner):
             )
         data = list((*x, y) for x, y in self.data.items())
         df = pandas.DataFrame(data, columns=[*point_names, value_name])
+        df.attrs["inputs"] = list(point_names)
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -185,6 +185,26 @@ class SequenceLearner(BaseLearner):
         x_name: str = "x",
         y_name: str = "y",
     ):
+        """Load data from a `pandas.DataFrame`.
+
+        If ``with_default_function_args`` is True, then ``learner.function``'s
+        default arguments are set (using `functools.partial`) from the values
+        in the `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            The data to load.
+        with_default_function_args : bool, optional
+            The ``with_default_function_args`` used in ``to_dataframe()``,
+            by default True
+        function_prefix : str, optional
+            The ``function_prefix`` used in ``to_dataframe``, by default "function."
+        x_name : str, optional
+            The ``x_name`` used in ``to_dataframe``, by default "x"
+        y_name : str, optional
+            The ``y_name`` used in ``to_dataframe``, by default "y"
+        """
         self.tell_many(df[[index_name, x_name]].values, df[y_name].values)
         if with_default_function_args:
             self.function = partial_function_from_dataframe(

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -150,7 +150,7 @@ class SequenceLearner(BaseLearner):
             Prefix to the ``learner.function``'s default arguments' names,
             by default "function."
         index_name : str, optional
-            Name of the index parameter, by default "index"
+            Name of the index parameter, by default "i"
         x_name : str, optional
             Name of the input value, by default "x"
         y_name : str, optional
@@ -200,6 +200,8 @@ class SequenceLearner(BaseLearner):
             by default True
         function_prefix : str, optional
             The ``function_prefix`` used in ``to_dataframe``, by default "function."
+        index_name : str, optional
+            The ``index_name`` used in ``to_dataframe``, by default "i"
         x_name : str, optional
             The ``x_name`` used in ``to_dataframe``, by default "x"
         y_name : str, optional

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import copy
 
 import cloudpickle
@@ -150,7 +152,7 @@ class SequenceLearner(BaseLearner):
 
     def load_dataframe(
         self,
-        df,
+        df: pandas.DataFrame,
         with_default_function_args: bool = True,
         function_prefix: str = "function.",
         index_name: str = "i",

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -139,6 +139,32 @@ class SequenceLearner(BaseLearner):
         x_name: str = "x",
         y_name: str = "y",
     ) -> pandas.DataFrame:
+        """Return the data as a `pandas.DataFrame`.
+
+        Parameters
+        ----------
+        with_default_function_args : bool, optional
+            Include the ``learner.function``'s default arguments as a
+            column, by default True
+        function_prefix : str, optional
+            Prefix to the ``learner.function``'s default arguments' names,
+            by default "function."
+        index_name : str, optional
+            Name of the index parameter, by default "index"
+        x_name : str, optional
+            Name of the input value, by default "x"
+        y_name : str, optional
+            Name of the output value, by default "y"
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Raises
+        ------
+        ImportError
+            If `pandas` is not installed.
+        """
         if not with_pandas:
             raise ImportError("pandas is not installed.")
         indices, ys = zip(*self.data.items()) if self.data else ([], [])

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -172,6 +172,8 @@ class SequenceLearner(BaseLearner):
         df = pandas.DataFrame(indices, columns=[index_name])
         df[x_name] = sequence
         df[y_name] = ys
+        df.attrs["inputs"] = [index_name]
+        df.attrs["output"] = y_name
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -4,7 +4,7 @@ import cloudpickle
 from sortedcontainers import SortedDict, SortedSet
 
 from adaptive.learner.base_learner import BaseLearner
-from adaptive.utils import assign_defaults
+from adaptive.utils import assign_defaults, partial_function_from_dataframe
 
 try:
     import pandas
@@ -147,6 +147,21 @@ class SequenceLearner(BaseLearner):
         if with_default_function_args:
             assign_defaults(self.function, df, function_prefix)
         return df
+
+    def load_dataframe(
+        self,
+        df,
+        with_default_function_args: bool = True,
+        function_prefix: str = "function.",
+        index_name: str = "i",
+        x_name: str = "x",
+        y_name: str = "y",
+    ):
+        self.tell_many(df[[index_name, x_name]].values, df[y_name].values)
+        if with_default_function_args:
+            self.function = partial_function_from_dataframe(
+                self.function, df, function_prefix
+            )
 
     def _get_data(self):
         return self.data

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -714,7 +714,7 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
     learner = learner_type(generate_random_parametrization(f), **learner_kwargs)
 
     # Test empty dataframe
-    df = learner.to_dataframe()
+    df = learner.to_dataframe(**kw)
     assert len(df) == 0
 
     # Run the learner

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -783,3 +783,13 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
         assert len(df) == data_saver.nsamples
     else:
         assert len(df) == data_saver.npoints
+
+    # Test loading from a DataFrame into a new DataSaver
+    learner2 = learner_type(learner.function, **learner_kwargs)
+    data_saver2 = DataSaver(learner2, operator.itemgetter("result"))
+    data_saver2.load_dataframe(df, **kw)
+    assert data_saver2.extra_data.keys() == data_saver.extra_data.keys()
+    assert all(
+        data_saver2.extra_data[k] == data_saver.extra_data[k]
+        for k in data_saver.extra_data.keys()
+    )

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -736,12 +736,19 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
         learner_type(generate_random_parametrization(f), **learner_kwargs)
         for _ in range(2)
     ]
-    learner = BalancingLearner(learners)
-    simple_run(learner, 100)
-    df = learner.to_dataframe(**kw)
-    assert isinstance(df, pandas.DataFrame)
+    bal_learner = BalancingLearner(learners)
+    simple_run(bal_learner, 100)
+    df_bal = bal_learner.to_dataframe(**kw)
+    assert isinstance(df_bal, pandas.DataFrame)
 
     if learner_type is not AverageLearner1D:
-        assert len(df) == learner.npoints
+        assert len(df_bal) == bal_learner.npoints
 
-    # TODO: Test this for a learner in a DataSaver
+    # Test loading from a DataFrame into the BalancingLearner
+    learners2 = [
+        learner_type(generate_random_parametrization(f), **learner_kwargs)
+        for _ in range(2)
+    ]
+    bal_learner2 = BalancingLearner(learners2)
+    bal_learner2.load_dataframe(df_bal, **kw)
+    assert bal_learner2.npoints == bal_learner.npoints

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -722,22 +722,7 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
 
     # Add points from the DataFrame to a new empty learner
     learner2 = learner_type(generate_random_parametrization(f), **learner_kwargs)
-
-    if learner_type is Learner1D:
-        learner2.tell_many(df["x"], df["y"])
-    elif learner_type is Learner2D:
-        learner2.tell_many(df[["x", "y"]].values, df["z"])
-    elif learner_type is LearnerND:
-        point_names = list(kw["point_names"])
-        learner2.tell_many(df[point_names].values, df["value"])
-    elif learner_type is AverageLearner:
-        learner2.tell_many(df["seed"].values, df["y"])
-    elif learner_type is AverageLearner1D:
-        learner2.tell_many(df[["seed", "x"]].values, df["y"])
-    elif learner_type is SequenceLearner:
-        learner2.tell_many(df[["i", "x"]].values, df["y"])
-    else:
-        raise NotImplementedError()
+    learner2.load_dataframe(df, **kw)
 
     # Test this for a learner in a BalancingLearner
     learners = [

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -703,11 +703,11 @@ def test_learner_subdomain(learner_type, f, learner_kwargs):
     LearnerND,
     AverageLearner,
     AverageLearner1D,
-    # SequenceLearner,  # TODO: implement this
+    SequenceLearner,
 )
 def test_to_dataframe(learner_type, f, learner_kwargs):
     if learner_type is LearnerND:
-        kw = {"point_names": list("xyz")[: len(learner_kwargs["bounds"])]}
+        kw = {"point_names": tuple("xyz")[: len(learner_kwargs["bounds"])]}
     else:
         kw = {}
 
@@ -734,6 +734,8 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
         learner2.tell_many(df["seed"].values, df["y"])
     elif learner_type is AverageLearner1D:
         learner2.tell_many(df[["seed", "x"]].values, df["y"])
+    elif learner_type is SequenceLearner:
+        learner2.tell_many(df[["i", "x"]].values, df["y"])
     else:
         raise NotImplementedError()
 

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -712,6 +712,12 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
         kw = {}
 
     learner = learner_type(generate_random_parametrization(f), **learner_kwargs)
+
+    # Test empty dataframe
+    df = learner.to_dataframe()
+    assert len(df) == 0
+
+    # Run the learner
     simple_run(learner, 100)
     df = learner.to_dataframe(**kw)
     assert isinstance(df, pandas.DataFrame)
@@ -721,8 +727,9 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
         assert len(df) == learner.npoints
 
     # Add points from the DataFrame to a new empty learner
-    learner2 = learner_type(generate_random_parametrization(f), **learner_kwargs)
+    learner2 = learner_type(learner.function, **learner_kwargs)
     learner2.load_dataframe(df, **kw)
+    assert learner2.npoints == learner.npoints
 
     # Test this for a learner in a BalancingLearner
     learners = [

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -729,6 +729,8 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
     # Test empty dataframe
     df = learner.to_dataframe(**kw)
     assert len(df) == 0
+    assert "inputs" in df.attrs
+    assert "output" in df.attrs
 
     # Run the learner
     simple_run(learner, 100)

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -101,7 +101,9 @@ class _RequireAttrsABCMeta(abc.ABCMeta):
         return obj
 
 
-def _default_parameters(function, function_prefix: str = "", start_index: int = 1):
+def _default_parameters(
+    function, function_prefix: str = "function.", start_index: int = 1
+):
     sig = inspect.signature(function)
     defaults = {
         f"{function_prefix}{k}": v.default
@@ -111,13 +113,20 @@ def _default_parameters(function, function_prefix: str = "", start_index: int = 
     return defaults
 
 
-def assign_defaults(function, df, function_prefix: str = "", start_index: int = 1):
+def assign_defaults(
+    function, df, function_prefix: str = "function.", start_index: int = 1
+):
     defaults = _default_parameters(function, function_prefix, start_index)
     for k, v in defaults.items():
         df[k] = len(df) * [v]
 
 
-def partial_function_from_dataframe(function, df, function_prefix: str = ""):
+def partial_function_from_dataframe(function, df, function_prefix: str = "function."):
+    if function_prefix == "":
+        raise ValueError(
+            "The function_prefix cannot be an empty string because"
+            " it is used to distinguish between function and learner parameters."
+        )
     kwargs = {}
     for col in df.columns:
         if col.startswith(function_prefix):

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -101,22 +101,18 @@ class _RequireAttrsABCMeta(abc.ABCMeta):
         return obj
 
 
-def _default_parameters(
-    function, function_prefix: str = "function.", start_index: int = 1
-):
+def _default_parameters(function, function_prefix: str = "function."):
     sig = inspect.signature(function)
     defaults = {
         f"{function_prefix}{k}": v.default
         for i, (k, v) in enumerate(sig.parameters.items())
-        if v.default != inspect._empty and i >= start_index
+        if v.default != inspect._empty and i >= 1
     }
     return defaults
 
 
-def assign_defaults(
-    function, df, function_prefix: str = "function.", start_index: int = 1
-):
-    defaults = _default_parameters(function, function_prefix, start_index)
+def assign_defaults(function, df, function_prefix: str = "function."):
+    defaults = _default_parameters(function, function_prefix)
     for k, v in defaults.items():
         df[k] = len(df) * [v]
         df[k] = df[k].astype("category")

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -109,3 +109,9 @@ def default_parameters(function, function_prefix="", start_index=1):
         if v.default != inspect._empty and i >= start_index
     }
     return defaults
+
+
+def assign_defaults(function, df, function_prefix="", start_index=1):
+    defaults = default_parameters(function, function_prefix, start_index)
+    for k, v in defaults.items():
+        df[k] = len(df) * [v]

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -101,7 +101,7 @@ class _RequireAttrsABCMeta(abc.ABCMeta):
         return obj
 
 
-def _default_parameters(function, function_prefix="", start_index=1):
+def _default_parameters(function, function_prefix: str = "", start_index: int = 1):
     sig = inspect.signature(function)
     defaults = {
         f"{function_prefix}{k}": v.default
@@ -111,7 +111,22 @@ def _default_parameters(function, function_prefix="", start_index=1):
     return defaults
 
 
-def assign_defaults(function, df, function_prefix="", start_index=1):
+def assign_defaults(function, df, function_prefix: str = "", start_index: int = 1):
     defaults = _default_parameters(function, function_prefix, start_index)
     for k, v in defaults.items():
         df[k] = len(df) * [v]
+
+
+def partial_function_from_dataframe(function, df, function_prefix: str = ""):
+    kwargs = {}
+    for col in df.columns:
+        if col.startswith(function_prefix):
+            k = col.split(function_prefix, 1)[1]
+            vs = df[col]
+            v, *rest = vs.unique()
+            if rest:
+                raise ValueError(f"The column '{col}' can only have one value.")
+            kwargs[k] = v
+    if not kwargs:
+        return function
+    return functools.partial(function, **kwargs)

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -119,6 +119,7 @@ def assign_defaults(
     defaults = _default_parameters(function, function_prefix, start_index)
     for k, v in defaults.items():
         df[k] = len(df) * [v]
+        df[k] = df[k].astype("category")
 
 
 def partial_function_from_dataframe(function, df, function_prefix: str = "function."):

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -101,7 +101,7 @@ class _RequireAttrsABCMeta(abc.ABCMeta):
         return obj
 
 
-def default_parameters(function, function_prefix="", start_index=1):
+def _default_parameters(function, function_prefix="", start_index=1):
     sig = inspect.signature(function)
     defaults = {
         f"{function_prefix}{k}": v.default
@@ -112,6 +112,6 @@ def default_parameters(function, function_prefix="", start_index=1):
 
 
 def assign_defaults(function, df, function_prefix="", start_index=1):
-    defaults = default_parameters(function, function_prefix, start_index)
+    defaults = _default_parameters(function, function_prefix, start_index)
     for k, v in defaults.items():
         df[k] = len(df) * [v]

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -1,6 +1,7 @@
 import abc
 import functools
 import gzip
+import inspect
 import os
 import pickle
 from contextlib import contextmanager
@@ -98,3 +99,13 @@ class _RequireAttrsABCMeta(abc.ABCMeta):
                     msg = f"The attribute '{name}' should be of type {type_}, not {type(x)}."
                     raise TypeError(msg)
         return obj
+
+
+def default_parameters(function, function_prefix="", start_index=1):
+    sig = inspect.signature(function)
+    defaults = {
+        f"{function_prefix}{k}": v.default
+        for i, (k, v) in enumerate(sig.parameters.items())
+        if v.default != inspect._empty and i >= start_index
+    }
+    return defaults

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - holoviews=1.14.6
   - bokeh=2.4.0
   - panel=0.12.7
+  - pandas=1.4.4
   - plotly=5.3.1
   - ipywidgets=7.6.5
   - myst-nb=0.16.0

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,9 +1,62 @@
-.ignore-css{all:unset !important;}
+.ignore-css {
+  all: unset !important;
+}
 
 /* https://gitter.im/pyviz/pyviz?at=5e8efb2b16f84f0461683446 */
 .panel-widget-box.bk form {
-    display: none !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-    width: 25%;
+  display: none !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  width: 25%;
+}
+
+/* Some additional styling taken form the Jupyter notebook CSS */
+/* but changed `rendered_html` to `text_html` */
+
+div.text_html table {
+  border: none;
+  border-collapse: collapse;
+  border-spacing: 0;
+  /* color: black; */
+  font-size: 12px;
+  table-layout: fixed;
+}
+div.text_html thead {
+  border-bottom: 1px solid;
+  vertical-align: bottom;
+}
+div.text_html tr,
+div.text_html th,
+div.text_html td {
+  text-align: right;
+  vertical-align: middle;
+  padding: 0.5em 0.5em;
+  line-height: normal;
+  white-space: normal;
+  max-width: none;
+  border: none;
+}
+div.text_html th {
+  font-weight: bold;
+}
+
+/* alternating color light theme */
+body[data-theme="light"] div.text_html tbody tr:nth-child(odd) {
+  background: #f5f5f5;
+}
+body[data-theme="light"] div.text_html tbody tr:hover {
+  background: rgba(66, 165, 245, 0.2);
+}
+
+/* alternating color dark theme */
+body[data-theme="dark"] div.text_html tbody tr:nth-child(odd) {
+  background: #696969;
+}
+body[data-theme="dark"] div.text_html tbody tr:hover {
+  background: rgba(175, 175, 175, 0.2);
+}
+
+/* for rendered markdown on meta_data.md docs */
+body[data-theme="dark"] .widget-html-content {
+  color: #f5f5f5;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ import adaptive  # noqa: E402, isort:skip
 # -- Project information -----------------------------------------------------
 
 project = "adaptive"
-copyright = "2018-2021, Adaptive Authors"
+copyright = "2018-2022, Adaptive Authors"
 author = "Adaptive Authors"
 
 # The short X.Y version

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -202,4 +202,26 @@ adaptive.runner.simple(learner_2, goal=npoints_goal)
 
 More info about using custom loss functions can be found in {ref}`Custom adaptive logic for 1D and 2D`.
 
+## Exporting the data
+
+We can view the raw data by looking at the dictionary `learner.data`.
+Alternatively, we can view the data as NumPy array with
+
+```{code-cell} ipython3
+learner.to_numpy()
+```
+
+If Pandas is installed (optional dependency), you can also run
+```{code-cell} ipython3
+df = learner.to_dataframe()
+df
+```
+
+and load that data into a new learner with
+```{code-cell} ipython3
+new_learner = adaptive.Learner1D(sin_exp, (-1, 1))  # create an empty learner
+new_learner.load_dataframe(df)  # load the pandas.DataFrame's data
+new_learner.plot()
+```
+
 [^download]: This notebook can be downloaded as **{nb-download}`tutorial.Learner1D.ipynb`** and {download}`tutorial.Learner1D.md`.

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -219,7 +219,7 @@ df
 
 and load that data into a new learner with
 ```{code-cell} ipython3
-new_learner = adaptive.Learner1D(sin_exp, (-1, 1))  # create an empty learner
+new_learner = adaptive.Learner1D(learner.function, (-1, 1))  # create an empty learner
 new_learner.load_dataframe(df)  # load the pandas.DataFrame's data
 new_learner.plot()
 ```

--- a/example-notebook.ipynb
+++ b/example-notebook.ipynb
@@ -1262,6 +1262,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Alternatively, you can save the learner's data as a `pandas.DataFrame` like"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = learner.to_dataframe()\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And load it into an empty learner with"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This will even set the default arguments to the function `peak`\n",
+    "# so we do not need to partial it\n",
+    "control = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
+    "control.load_dataframe(df)\n",
+    "learner.plot().relabel(\"saved learner\") + control.plot().relabel(\"loaded learner\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## A watched pot never boils!"
    ]
   },


### PR DESCRIPTION
## Description

This code in this PR allows exporting a learner to a `pandas.DataFrame`. This will be useful when running many learners (e.g, in a `BalancingLearner`) and then being able to just concatenate the `DataFrame`s to get the combined result.

Currently saving the learner creates a `pickle` file and while this is fine for immediate use, for long term storage this is a bad practice.

I chose to use `pandas` over `xarray` because we are dealing with tabular data instead of ND dense or sparse arrays.

Ping @CameronKing

Example:
<img width="696" alt="image" src="https://user-images.githubusercontent.com/6897215/189978108-f2cf905b-50da-464d-979a-905ecff3dcbb.png">


## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
