### PR TITLE
Add Learner.new() method that returns an empty copy of the learner

### DIFF
--- a/adaptive/learner/average_learner.py
+++ b/adaptive/learner/average_learner.py
@@ -74,6 +74,10 @@ class AverageLearner(BaseLearner):
         self.sum_f: Real = 0.0
         self.sum_f_sq: Real = 0.0
 
+    def new(self) -> AverageLearner:
+        """Create a copy of `~adaptive.AverageLearner` without the data."""
+        return AverageLearner(self.function, self.atol, self.rtol, self.min_npoints)
+
     @property
     def n_requested(self) -> int:
         return self.npoints + len(self.pending_points)

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -125,6 +125,20 @@ class AverageLearner1D(Learner1D):
         # {xii: error[xii]/min(_distances[xi], _distances[xii], ...}
         self.rescaled_error: dict[Real, float] = decreasing_dict()
 
+    def new(self) -> AverageLearner1D:
+        """Create a copy of `~adaptive.AverageLearner1D` without the data."""
+        return AverageLearner1D(
+            self.function,
+            self.bounds,
+            self.loss_per_interval,
+            self.delta,
+            self.alpha,
+            self.neighbor_sampling,
+            self.min_samples,
+            self.max_samples,
+            self.min_error,
+        )
+
     @property
     def nsamples(self) -> int:
         """Returns the total number of samples"""

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from collections import defaultdict
 from collections.abc import Iterable
@@ -95,6 +97,14 @@ class BalancingLearner(BaseLearner):
             )
 
         self.strategy = strategy
+
+    def new(self) -> BalancingLearner:
+        """Create a new `BalancingLearner` with the same parameters."""
+        return BalancingLearner(
+            [learner.new() for learner in self.learners],
+            cdims=self._cdims_default,
+            strategy=self.strategy,
+        )
 
     @property
     def data(self):

--- a/adaptive/learner/base_learner.py
+++ b/adaptive/learner/base_learner.py
@@ -149,6 +149,11 @@ class BaseLearner(metaclass=_RequireAttrsABCMeta):
     def _set_data(self):
         pass
 
+    @abc.abstractmethod
+    def new(self):
+        """Return a new learner with the same function and parameters."""
+        pass
+
     def copy_from(self, other):
         """Copy over the data from another learner.
 

--- a/adaptive/learner/data_saver.py
+++ b/adaptive/learner/data_saver.py
@@ -45,6 +45,10 @@ class DataSaver:
         self.function = learner.function
         self.arg_picker = arg_picker
 
+    def new(self) -> DataSaver:
+        """Return a new `DataSaver` with the same `arg_picker` and `learner`."""
+        return DataSaver(self.learner.new(), self.arg_picker)
+
     def __getattr__(self, attr):
         return getattr(self.learner, attr)
 

--- a/adaptive/learner/integrator_learner.py
+++ b/adaptive/learner/integrator_learner.py
@@ -1,4 +1,5 @@
 # Based on an adaptive quadrature algorithm by Pedro Gonnet
+from __future__ import annotations
 
 import sys
 from collections import defaultdict
@@ -380,6 +381,10 @@ class IntegratorLearner(BaseLearner):
         ival = _Interval.make_first(*self.bounds)
         self.add_ival(ival)
         self.first_ival = ival
+
+    def new(self) -> IntegratorLearner:
+        """Create a copy of `~adaptive.Learner2D` without the data."""
+        return IntegratorLearner(self.function, self.bounds, self.tol)
 
     @property
     def approximating_intervals(self):

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -303,10 +303,14 @@ class Learner1D(BaseLearner):
         # The precision in 'x' below which we set losses to 0.
         self._dx_eps = 2 * max(np.abs(bounds)) * np.finfo(float).eps
 
-        self.bounds = list(bounds)
+        self.bounds = tuple(bounds)
         self.__missing_bounds = set(self.bounds)  # cache of missing bounds
 
         self._vdim: int | None = None
+
+    def new(self) -> Learner1D:
+        """Create a copy of `~adaptive.Learner1D` without the data."""
+        return Learner1D(self.function, self.bounds, self.loss_per_interval)
 
     @property
     def vdim(self) -> int:

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -384,6 +384,9 @@ class Learner2D(BaseLearner):
 
         self.stack_size = 10
 
+    def new(self) -> Learner2D:
+        return Learner2D(self.function, self.bounds, self.loss_per_triangle)
+
     @property
     def xy_scale(self):
         xy_scale = self._xy_scale

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -376,6 +376,10 @@ class LearnerND(BaseLearner):
         # _pop_highest_existing_simplex
         self._simplex_queue = SortedKeyList(key=_simplex_evaluation_priority)
 
+    def new(self) -> LearnerND:
+        """Create a new learner with the same function and bounds."""
+        return LearnerND(self.function, self.bounds, self.loss_per_simplex)
+
     @property
     def npoints(self):
         """Number of evaluated points."""

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -77,6 +77,10 @@ class SequenceLearner(BaseLearner):
         self.data = SortedDict()
         self.pending_points = set()
 
+    def new(self) -> SequenceLearner:
+        """Return a new `~adaptive.SequenceLearner` without the data."""
+        return SequenceLearner(self._original_function, self.sequence)
+
     def ask(self, n, tell_pending=True):
         indices = []
         points = []

--- a/adaptive/learner/skopt_learner.py
+++ b/adaptive/learner/skopt_learner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 
 import numpy as np
@@ -27,7 +29,12 @@ class SKOptLearner(Optimizer, BaseLearner):
         self.function = function
         self.pending_points = set()
         self.data = collections.OrderedDict()
+        self._kwargs = kwargs
         super().__init__(**kwargs)
+
+    def new(self) -> SKOptLearner:
+        """Return a new `~adaptive.SKOptLearner` without the data."""
+        return SKOptLearner(self.function, **self._kwargs)
 
     def tell(self, x, y, fit=True):
         if isinstance(x, collections.abc.Iterable):

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -294,7 +294,7 @@ def test_adding_existing_data_is_idempotent(learner_type, f, learner_kwargs):
     """
     f = generate_random_parametrization(f)
     learner = learner_type(f, **learner_kwargs)
-    control = learner_type(f, **learner_kwargs)
+    control = learner.new()
     if learner_type in (Learner1D, AverageLearner1D):
         learner._recompute_losses_factor = 1
         control._recompute_losses_factor = 1
@@ -345,7 +345,7 @@ def test_adding_non_chosen_data(learner_type, f, learner_kwargs):
     # XXX: learner, control and bounds are not defined
     f = generate_random_parametrization(f)
     learner = learner_type(f, **learner_kwargs)
-    control = learner_type(f, **learner_kwargs)
+    control = learner.new()
 
     if learner_type is Learner2D:
         # If the stack_size is bigger then the number of points added,
@@ -395,7 +395,7 @@ def test_point_adding_order_is_irrelevant(learner_type, f, learner_kwargs):
     """
     f = generate_random_parametrization(f)
     learner = learner_type(f, **learner_kwargs)
-    control = learner_type(f, **learner_kwargs)
+    control = learner.new()
 
     if learner_type in (Learner1D, AverageLearner1D):
         learner._recompute_losses_factor = 1
@@ -581,7 +581,7 @@ def test_balancing_learner(learner_type, f, learner_kwargs):
 def test_saving(learner_type, f, learner_kwargs):
     f = generate_random_parametrization(f)
     learner = learner_type(f, **learner_kwargs)
-    control = learner_type(f, **learner_kwargs)
+    control = learner.new()
     if learner_type in (Learner1D, AverageLearner1D):
         learner._recompute_losses_factor = 1
         control._recompute_losses_factor = 1
@@ -614,7 +614,7 @@ def test_saving(learner_type, f, learner_kwargs):
 def test_saving_of_balancing_learner(learner_type, f, learner_kwargs):
     f = generate_random_parametrization(f)
     learner = BalancingLearner([learner_type(f, **learner_kwargs)])
-    control = BalancingLearner([learner_type(f, **learner_kwargs)])
+    control = learner.new()
 
     if learner_type in (Learner1D, AverageLearner1D):
         for l, c in zip(learner.learners, control.learners):
@@ -654,7 +654,7 @@ def test_saving_with_datasaver(learner_type, f, learner_kwargs):
     g = lambda x: {"y": f(x), "t": random.random()}  # noqa: E731
     arg_picker = operator.itemgetter("y")
     learner = DataSaver(learner_type(g, **learner_kwargs), arg_picker)
-    control = DataSaver(learner_type(g, **learner_kwargs), arg_picker)
+    control = learner.new()
 
     if learner_type in (Learner1D, AverageLearner1D):
         learner.learner._recompute_losses_factor = 1
@@ -742,7 +742,7 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
         assert len(df) == learner.npoints
 
     # Add points from the DataFrame to a new empty learner
-    learner2 = learner_type(learner.function, **learner_kwargs)
+    learner2 = learner.new()
     learner2.load_dataframe(df, **kw)
     assert learner2.npoints == learner.npoints
 
@@ -787,8 +787,7 @@ def test_to_dataframe(learner_type, f, learner_kwargs):
         assert len(df) == data_saver.npoints
 
     # Test loading from a DataFrame into a new DataSaver
-    learner2 = learner_type(learner.function, **learner_kwargs)
-    data_saver2 = DataSaver(learner2, operator.itemgetter("result"))
+    data_saver2 = data_saver.new()
     data_saver2.load_dataframe(df, **kw)
     assert data_saver2.extra_data.keys() == data_saver.extra_data.keys()
     assert all(


### PR DESCRIPTION
## Description

Add a method that returns a new instance of the `Learner` but without any data.

This is useful for testing and very useful when sending `Learner`s over the network where its data is stored separately, e.g., in https://github.com/basnijholt/adaptive-scheduler.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
