### PR TITLE
Add loss_goal, npoints_goal, and an auto_goal function and use it in the runners

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ def peak(x, a=0.01):
 
 
 learner = Learner1D(peak, bounds=(-1, 1))
-runner = Runner(learner, goal=0.01)
+runner = Runner(learner, loss_goal=0.01)
 runner.live_info()
 runner.live_plot()
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ def peak(x, a=0.01):
 
 
 learner = Learner1D(peak, bounds=(-1, 1))
-runner = Runner(learner, goal=lambda l: l.loss() < 0.01)
+runner = Runner(learner, goal=0.01)
 runner.live_info()
 runner.live_plot()
 ```

--- a/adaptive/__init__.py
+++ b/adaptive/__init__.py
@@ -1,6 +1,5 @@
 from contextlib import suppress
 
-from adaptive import learner, runner, utils
 from adaptive._version import __version__
 from adaptive.learner import (
     AverageLearner,
@@ -21,6 +20,8 @@ from adaptive.notebook_integration import (
     notebook_extension,
 )
 from adaptive.runner import AsyncRunner, BlockingRunner, Runner
+
+from adaptive import learner, runner, utils  # isort:skip
 
 __all__ = [
     "learner",

--- a/adaptive/learner/data_saver.py
+++ b/adaptive/learner/data_saver.py
@@ -20,7 +20,7 @@ def _to_key(x):
     return tuple(x.values) if x.values.size > 1 else x.item()
 
 
-class DataSaver:
+class DataSaver(BaseLearner):
     """Save extra data associated with the values that need to be learned.
 
     Parameters
@@ -49,6 +49,18 @@ class DataSaver:
     def new(self) -> DataSaver:
         """Return a new `DataSaver` with the same `arg_picker` and `learner`."""
         return DataSaver(self.learner.new(), self.arg_picker)
+
+    @copy_docstring_from(BaseLearner.ask)
+    def ask(self, *args, **kwargs):
+        return self.learner.ask(*args, **kwargs)
+
+    @copy_docstring_from(BaseLearner.loss)
+    def loss(self, *args, **kwargs):
+        return self.learner.loss(*args, **kwargs)
+
+    @copy_docstring_from(BaseLearner.remove_unfinished)
+    def remove_unfinished(self, *args, **kwargs):
+        return self.learner.remove_unfinished(*args, **kwargs)
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self.learner, attr)

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -29,7 +29,7 @@ from adaptive.notebook_integration import in_ipynb, live_info, live_plot
 
 try:
     from typing import TypeAlias
-except ModuleNotFoundError:
+except ImportError:
     # Python <3.10
     from typing_extensions import TypeAlias
 

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -14,7 +14,7 @@ import traceback
 import warnings
 from contextlib import suppress
 from datetime import datetime, timedelta
-from typing import Any, Callable, Union
+from typing import Any, Callable
 
 import loky
 
@@ -26,12 +26,6 @@ from adaptive import (
     SequenceLearner,
 )
 from adaptive.notebook_integration import in_ipynb, live_info, live_plot
-
-try:
-    from typing import TypeAlias
-except ImportError:
-    # Python <3.10
-    from typing_extensions import TypeAlias
 
 try:
     import ipyparallel
@@ -71,10 +65,6 @@ else:
     # See https://docs.python.org/3/library/concurrent.futures.html#processpoolexecutor
     # and https://github.com/python-adaptive/adaptive/issues/301
     _default_executor = loky.get_reusable_executor
-
-_GoalTypes: TypeAlias = Union[
-    Callable[[BaseLearner], bool], int, float, datetime, timedelta, None
-]
 
 
 class BaseRunner(metaclass=abc.ABCMeta):

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -738,6 +738,7 @@ def simple(learner, goal):
         The end condition for the calculation. This function must take the
         learner as its sole argument, and return True if we should stop.
     """
+    goal = auto_goal(goal, learner)
     while not goal(learner):
         xs, _ = learner.ask(1)
         for x in xs:

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -144,8 +144,8 @@ class BaseRunner(metaclass=abc.ABCMeta):
     def __init__(
         self,
         learner,
-        *,
         goal: GoalTypes = None,
+        *,
         loss_goal: float | None = None,
         npoints_goal: int | None = None,
         executor=None,
@@ -410,8 +410,8 @@ class BlockingRunner(BaseRunner):
     def __init__(
         self,
         learner,
-        *,
         goal: GoalTypes = None,
+        *,
         loss_goal: float | None = None,
         npoints_goal: int | None = None,
         executor=None,
@@ -555,8 +555,8 @@ class AsyncRunner(BaseRunner):
     def __init__(
         self,
         learner,
-        *,
         goal: GoalTypes = None,
+        *,
         loss_goal: float | None = None,
         npoints_goal: int | None = None,
         executor=None,
@@ -770,8 +770,8 @@ Runner = AsyncRunner
 
 def simple(
     learner,
-    *,
     goal: GoalTypes = None,
+    *,
     loss_goal: float | None = None,
     npoints_goal: int | None = None,
 ):

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -876,7 +876,7 @@ class _TimeGoal:
         elif isinstance(self.dt, datetime):
             return datetime.now() > self.dt
         else:
-            raise TypeError(f"{self.dt=} is not a datetime or timedelta.")
+            raise TypeError(f"`dt={self.dt}` is not a datetime or timedelta.")
 
 
 def auto_goal(

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -149,7 +149,7 @@ class BaseRunner(metaclass=abc.ABCMeta):
         loss_goal: float | None = None,
         npoints_goal: int | None = None,
         end_time_goal: datetime | None = None,
-        duration_goal: timedelta | None = None,
+        duration_goal: timedelta | int | float | None = None,
         executor=None,
         ntasks=None,
         log=False,
@@ -424,7 +424,7 @@ class BlockingRunner(BaseRunner):
         loss_goal: float | None = None,
         npoints_goal: int | None = None,
         end_time_goal: datetime | None = None,
-        duration_goal: timedelta | None = None,
+        duration_goal: timedelta | int | float | None = None,
         executor=None,
         ntasks=None,
         log=False,
@@ -583,7 +583,7 @@ class AsyncRunner(BaseRunner):
         loss_goal: float | None = None,
         npoints_goal: int | None = None,
         end_time_goal: datetime | None = None,
-        duration_goal: timedelta | None = None,
+        duration_goal: timedelta | int | float | None = None,
         executor=None,
         ntasks=None,
         log=False,
@@ -802,7 +802,7 @@ def simple(
     loss_goal: float | None = None,
     npoints_goal: int | None = None,
     end_time_goal: datetime | None = None,
-    duration_goal: timedelta | None = None,
+    duration_goal: timedelta | int | float | None = None,
 ):
     """Run the learner until the goal is reached.
 
@@ -995,7 +995,7 @@ def auto_goal(
     loss: float | None = None,
     npoints: int | None = None,
     end_time: datetime | None = None,
-    duration: timedelta | int | None = None,
+    duration: timedelta | int | float | None = None,
     learner: BaseLearner | None = None,
     allow_running_forever: bool = True,
 ) -> Callable[[BaseLearner], bool]:

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -88,7 +88,7 @@ class BaseRunner(metaclass=abc.ABCMeta):
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than this
         value.
-    timedelta_goal : timedelta, optional
+    timedelta_goal : timedelta or int, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
         ``start_time + timedelta_goal``.
@@ -507,7 +507,7 @@ class AsyncRunner(BaseRunner):
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than this
         value.
-    timedelta_goal : timedelta, optional
+    timedelta_goal : timedelta or int, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
         ``start_time + timedelta_goal``.
@@ -831,7 +831,7 @@ def simple(
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than this
         value.
-    timedelta_goal : timedelta, optional
+    timedelta_goal : timedelta or int, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
         ``start_time + timedelta_goal``.
@@ -970,7 +970,9 @@ def _get_ncores(ex):
 
 
 class _TimeGoal:
-    def __init__(self, dt: timedelta | datetime):
+    def __init__(self, dt: timedelta | datetime | int):
+        if isinstance(dt, int):
+            self.dt = timedelta(seconds=dt)
         self.dt = dt
         self.start_time = None
 
@@ -989,7 +991,7 @@ def auto_goal(
     loss: float | None = None,
     npoints: int | None = None,
     datetime: datetime | None = None,
-    timedelta: timedelta | None = None,
+    timedelta: timedelta | int | None = None,
     learner: BaseLearner | None = None,
     allow_running_forever: bool = True,
 ) -> Callable[[BaseLearner], bool]:
@@ -997,25 +999,14 @@ def auto_goal(
 
     Parameters
     ----------
-    goal
-        The goal to extract. Can be a callable, an integer, a float, a datetime,
-        a timedelta or None.
-        If the type of `goal` is:
-        * ``callable``, it is returned as is.
-        * ``int``, the goal is reached after that many points have been added.
-        * ``float``, the goal is reached when the learner has reached a loss
-          equal or less than that.
-        * `datetime.datetime`, the goal is reached when the current time is after the
-          datetime.
-        * `datetime.timedelta`, the goal is reached when the current time is after
-          the start time plus that timedelta.
-        * ``None`` and
-            * the learner type is `adaptive.SequenceLearner`, it continues until
-              it no more points to add
-            * the learner type is `adaptive.IntegratorLearner`, it continues until the
-              error is less than the tolerance specified in the learner.
-            * otherwise, it continues forever, unless ``allow_running_forever`` is
-              False, in which case it raises a ValueError.
+    loss
+        TODO
+    npoints
+        TODO
+    datetime
+        TODO
+    timedelta
+        TODO
     learner
         Learner for which to determine the goal.
     allow_running_forever

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -895,7 +895,7 @@ def auto_goal(
         If it is an integer, the goal is reached after that many points have been
         returned.
         If it is a float, the goal is reached when the learner has reached a loss
-        less than that.
+        equal or less than that.
         If it is a datetime, the goal is reached when the current time is after the
         datetime.
         If it is a timedelta, the goal is reached when the current time is after

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -891,22 +891,23 @@ def auto_goal(
     goal
         The goal to extract. Can be a callable, an integer, a float, a datetime,
         a timedelta or None.
-        If it is a callable, it is returned as is.
-        If it is an integer, the goal is reached after that many points have been
-        returned.
-        If it is a float, the goal is reached when the learner has reached a loss
-        equal or less than that.
-        If it is a datetime, the goal is reached when the current time is after the
-        datetime.
-        If it is a timedelta, the goal is reached when the current time is after
-        the start time plus that timedelta.
-        If it is None, and
-            - the learner type is `adaptive.SequenceLearner`, it continues until
-            it no more points to add
-            - the learner type is `adaptive.IntegratorLearner`, it continues until the
-            error is less than the tolerance specified in the learner.
-            - otherwise, it continues forever, unless `allow_running_forever` is
-            False, in which case it raises a ValueError.
+        If the type of `goal` is:
+
+        * ``callable``, it is returned as is.
+        * ``int``, the goal is reached after that many points have been added.
+        * ``float``, the goal is reached when the learner has reached a loss
+          equal or less than that.
+        * `datetime.datetime`, the goal is reached when the current time is after the
+          datetime.
+        * `datetime.timedelta`, the goal is reached when the current time is after
+          the start time plus that timedelta.
+        * ``None`` and
+            * the learner type is `adaptive.SequenceLearner`, it continues until
+              it no more points to add
+            * the learner type is `adaptive.IntegratorLearner`, it continues until the
+              error is less than the tolerance specified in the learner.
+            * otherwise, it continues forever, unless ``allow_running_forever`` is
+              False, in which case it raises a ValueError.
     learner
         Learner for which to determine the goal.
     allow_running_forever

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -366,6 +366,15 @@ class BlockingRunner(BaseRunner):
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the number of points is larger or
         equal than this value.
+    end_time_goal : datetime, optional
+        Convenience argument, use instead of ``goal``. The end condition for the
+        calculation. Stop when the current time is larger or equal than this
+        value.
+    duration_goal : timedelta or number, optional
+        Convenience argument, use instead of ``goal``. The end condition for the
+        calculation. Stop when the current time is larger or equal than
+        ``start_time + duration_goal``. ``duration_goal`` can be a number
+        indicating the number of seconds
     executor : `concurrent.futures.Executor`, `distributed.Client`,\
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -1023,7 +1023,8 @@ def auto_goal(
         ``start_time + duration``. ``duration`` can be a number
         indicating the number of seconds.
     learner
-        Learner for which to determine the goal.
+        Learner for which to determine the goal. Only used if the learner type
+        is `BalancingLearner`, `DataSaver`, `SequenceLearner`, or `IntegratorLearner`.
     allow_running_forever
         If True, and the goal is None and the learner is not a SequenceLearner,
         then a goal that never stops is returned, otherwise an exception is raised.

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -18,7 +18,13 @@ from typing import Any, Callable, Union
 
 import loky
 
-from adaptive import BalancingLearner, BaseLearner, IntegratorLearner, SequenceLearner
+from adaptive import (
+    BalancingLearner,
+    BaseLearner,
+    DataSaver,
+    IntegratorLearner,
+    SequenceLearner,
+)
 from adaptive.notebook_integration import in_ipynb, live_info, live_plot
 
 try:
@@ -955,6 +961,8 @@ def auto_goal(
         return lambda learner: learner.npoints >= goal
     if isinstance(goal, (timedelta, datetime)):
         return _TimeGoal(goal)
+    if isinstance(learner, DataSaver):
+        return auto_goal(goal, learner.learner, allow_running_forever)
     if goal is None:
         if isinstance(learner, SequenceLearner):
             return SequenceLearner.done

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -92,7 +92,7 @@ class BaseRunner(metaclass=abc.ABCMeta):
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
         ``start_time + duration_goal``. ``duration_goal`` can be a number
-        indicating the number of seconds
+        indicating the number of seconds.
     executor : `concurrent.futures.Executor`, `distributed.Client`,\
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional
@@ -355,14 +355,14 @@ class BlockingRunner(BaseRunner):
     Parameters
     ----------
     learner : `~adaptive.BaseLearner` instance
-    goal : callable
+    goal : callable, optional
         The end condition for the calculation. This function must take
         the learner as its sole argument, and return True when we should
         stop requesting more points.
-    loss_goal : float
+    loss_goal : float, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the loss is smaller than this value.
-    npoints_goal : int
+    npoints_goal : int, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the number of points is larger or
         equal than this value.
@@ -374,7 +374,7 @@ class BlockingRunner(BaseRunner):
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
         ``start_time + duration_goal``. ``duration_goal`` can be a number
-        indicating the number of seconds
+        indicating the number of seconds.
     executor : `concurrent.futures.Executor`, `distributed.Client`,\
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional
@@ -505,7 +505,7 @@ class AsyncRunner(BaseRunner):
         the learner as its sole argument, and return True when we should
         stop requesting more points.
         If not provided, the runner will run forever (or stop when no more
-        points can be added), or until ``self.task.cancel()`` is called.
+        points can be added), or until ``runner.task.cancel()`` is called.
     loss_goal : float, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the loss is smaller than this value.
@@ -827,7 +827,7 @@ def simple(
     Parameters
     ----------
     learner : ~`adaptive.BaseLearner` instance
-    goal : callable
+    goal : callable, optional
         The end condition for the calculation. This function must take
         the learner as its sole argument, and return True when we should
         stop requesting more points.

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -14,14 +14,12 @@ import traceback
 import warnings
 from contextlib import suppress
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 import loky
 
+from adaptive import BalancingLearner, BaseLearner, IntegratorLearner, SequenceLearner
 from adaptive.notebook_integration import in_ipynb, live_info, live_plot
-
-if TYPE_CHECKING:
-    from adaptive import BaseLearner
 
 try:
     import ipyparallel
@@ -918,8 +916,6 @@ def auto_goal(
     -------
     Callable[[adaptive.BaseLearner], bool]
     """
-    from adaptive import BalancingLearner, IntegratorLearner, SequenceLearner
-
     if callable(goal):
         return goal
     if isinstance(goal, float):

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -113,6 +113,8 @@ class BaseRunner(metaclass=abc.ABCMeta):
         the point is present in ``runner.failed``.
     raise_if_retries_exceeded : bool, default: True
         Raise the error after a point ``x`` failed `retries`.
+    allow_running_forever : bool, default: False
+        Allow the runner to run forever when the goal is None.
 
     Attributes
     ----------
@@ -436,6 +438,8 @@ class BlockingRunner(BaseRunner):
             goal=goal,
             loss_goal=loss_goal,
             npoints_goal=npoints_goal,
+            datetime_goal=datetime_goal,
+            timedelta_goal=timedelta_goal,
             executor=executor,
             ntasks=ntasks,
             log=log,
@@ -531,6 +535,8 @@ class AsyncRunner(BaseRunner):
         the point is present in ``runner.failed``.
     raise_if_retries_exceeded : bool, default: True
         Raise the error after a point ``x`` failed `retries`.
+    allow_running_forever : bool, default: True
+        If True, the runner will run forever if the goal is not provided.
 
     Attributes
     ----------
@@ -606,6 +612,8 @@ class AsyncRunner(BaseRunner):
             goal=goal,
             loss_goal=loss_goal,
             npoints_goal=npoints_goal,
+            datetime_goal=datetime_goal,
+            timedelta_goal=timedelta_goal,
             executor=executor,
             ntasks=ntasks,
             log=log,

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -91,7 +91,8 @@ class BaseRunner(metaclass=abc.ABCMeta):
     duration_goal : timedelta or number, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
-        ``start_time + duration_goal``.
+        ``start_time + duration_goal``. ``duration_goal`` can be a number
+        indicating the number of seconds
     executor : `concurrent.futures.Executor`, `distributed.Client`,\
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional
@@ -510,7 +511,8 @@ class AsyncRunner(BaseRunner):
     duration_goal : timedelta or number, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
-        ``start_time + duration_goal``.
+        ``start_time + duration_goal``. ``duration_goal`` can be a number
+        indicating the number of seconds.
     executor : `concurrent.futures.Executor`, `distributed.Client`,\
                `mpi4py.futures.MPIPoolExecutor`, `ipyparallel.Client` or\
                `loky.get_reusable_executor`, optional
@@ -834,7 +836,8 @@ def simple(
     duration_goal : timedelta or number, optional
         Convenience argument, use instead of ``goal``. The end condition for the
         calculation. Stop when the current time is larger or equal than
-        ``start_time + duration_goal``.
+        ``start_time + duration_goal``. ``duration_goal`` can be a number
+        indicating the number of seconds.
     """
     goal = _goal(
         learner,
@@ -1000,14 +1003,16 @@ def auto_goal(
 
     Parameters
     ----------
-    loss
-        TODO
-    npoints
-        TODO
-    end_time
-        TODO
-    duration
-        TODO
+    loss : float, optional
+        Stop when the loss is smaller than this value.
+    npoints : int, optional
+        Stop when the number of points is larger or equal than this value.
+    end_time : datetime, optional
+        Stop when the current time is larger or equal than this value.
+    duration : timedelta or number, optional
+        Stop when the current time is larger or equal than
+        ``start_time + duration``. ``duration`` can be a number
+        indicating the number of seconds.
     learner
         Learner for which to determine the goal.
     allow_running_forever

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -903,8 +903,8 @@ def auto_goal(
         If it is None, and
             - the learner type is `adaptive.SequenceLearner`, it continues until
             it no more points to add
-            - the learner type is `adaptive.Integrator`, it continues until the
-            error is less than the tolerance.
+            - the learner type is `adaptive.IntegratorLearner`, it continues until the
+            error is less than the tolerance specified in the learner.
             - otherwise, it continues forever, unless `allow_running_forever` is
             False, in which case it raises a ValueError.
     learner

--- a/adaptive/tests/test_average_learner.py
+++ b/adaptive/tests/test_average_learner.py
@@ -61,7 +61,7 @@ def test_min_npoints():
         learner = AverageLearner(
             constant_function, atol=0.01, rtol=0.01, min_npoints=min_npoints
         )
-        simple(learner, 1.0)
+        simple(learner, loss_goal=1.0)
         assert learner.npoints >= max(2, min_npoints)
 
 

--- a/adaptive/tests/test_average_learner.py
+++ b/adaptive/tests/test_average_learner.py
@@ -61,7 +61,7 @@ def test_min_npoints():
         learner = AverageLearner(
             constant_function, atol=0.01, rtol=0.01, min_npoints=min_npoints
         )
-        simple(learner, lambda l: l.loss() < 1)
+        simple(learner, 1.0)
         assert learner.npoints >= max(2, min_npoints)
 
 

--- a/adaptive/tests/test_balancing_learner.py
+++ b/adaptive/tests/test_balancing_learner.py
@@ -50,15 +50,15 @@ def test_ask_0(strategy):
 
 
 @pytest.mark.parametrize(
-    "strategy, goal",
+    "strategy, goal_type, goal",
     [
-        ("loss", 0.1),
-        ("loss_improvements", 0.1),
-        ("npoints", lambda bl: all(l.npoints > 10 for l in bl.learners)),
-        ("cycle", 0.1),
+        ("loss", "loss_goal", 0.1),
+        ("loss_improvements", "loss_goal", 0.1),
+        ("npoints", "goal", lambda bl: all(l.npoints > 10 for l in bl.learners)),
+        ("cycle", "loss_goal", 0.1),
     ],
 )
-def test_strategies(strategy, goal):
+def test_strategies(strategy, goal_type, goal):
     learners = [Learner1D(lambda x: x, bounds=(-1, 1)) for i in range(10)]
     learner = BalancingLearner(learners, strategy=strategy)
-    simple(learner, goal=goal)
+    simple(learner, **{goal_type: goal})

--- a/adaptive/tests/test_balancing_learner.py
+++ b/adaptive/tests/test_balancing_learner.py
@@ -52,10 +52,10 @@ def test_ask_0(strategy):
 @pytest.mark.parametrize(
     "strategy, goal",
     [
-        ("loss", lambda l: l.loss() < 0.1),
-        ("loss_improvements", lambda l: l.loss() < 0.1),
+        ("loss", 0.1),
+        ("loss_improvements", 0.1),
         ("npoints", lambda bl: all(l.npoints > 10 for l in bl.learners)),
-        ("cycle", lambda l: l.loss() < 0.1),
+        ("cycle", 0.1),
     ],
 )
 def test_strategies(strategy, goal):

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -375,7 +375,7 @@ def test_curvature_loss():
     assert loss.nth_neighbors == 1
     learner = Learner1D(f, (-1, 1), loss_per_interval=loss)
     simple(learner, goal=100)
-    assert learner.npoints > 100
+    assert learner.npoints >= 100
 
 
 def test_curvature_loss_vectors():
@@ -386,7 +386,7 @@ def test_curvature_loss_vectors():
     assert loss.nth_neighbors == 1
     learner = Learner1D(f, (-1, 1), loss_per_interval=loss)
     simple(learner, goal=100)
-    assert learner.npoints > 100
+    assert learner.npoints >= 100
 
 
 def test_NaN_loss():

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -298,7 +298,7 @@ def test_tell_many():
     for function in [f, f_vec]:
         learner = Learner1D(function, bounds=(-1, 1))
         learner2 = Learner1D(function, bounds=(-1, 1))
-        simple(learner, goal=200)
+        simple(learner, npoints_goal=200)
         xs, ys = zip(*learner.data.items())
 
         # Make the scale huge to no get a scale doubling
@@ -374,7 +374,7 @@ def test_curvature_loss():
     loss = curvature_loss_function()
     assert loss.nth_neighbors == 1
     learner = Learner1D(f, (-1, 1), loss_per_interval=loss)
-    simple(learner, goal=100)
+    simple(learner, npoints_goal=100)
     assert learner.npoints >= 100
 
 
@@ -385,7 +385,7 @@ def test_curvature_loss_vectors():
     loss = curvature_loss_function()
     assert loss.nth_neighbors == 1
     learner = Learner1D(f, (-1, 1), loss_per_interval=loss)
-    simple(learner, goal=100)
+    simple(learner, npoints_goal=100)
     assert learner.npoints >= 100
 
 
@@ -398,7 +398,7 @@ def test_NaN_loss():
         return x + a**2 / (a**2 + x**2)
 
     learner = Learner1D(f, bounds=(-1, 1))
-    simple(learner, 100)
+    simple(learner, npoints_goal=100)
 
 
 def test_inf_loss_with_missing_bounds():
@@ -408,6 +408,6 @@ def test_inf_loss_with_missing_bounds():
         loss_per_interval=curvature_loss_function(),
     )
     # must be done in parallel because otherwise the bounds will be evaluated first
-    BlockingRunner(learner, goal=0.01)
+    BlockingRunner(learner, loss_goal=0.01)
 
     learner.npoints > 20

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -298,7 +298,7 @@ def test_tell_many():
     for function in [f, f_vec]:
         learner = Learner1D(function, bounds=(-1, 1))
         learner2 = Learner1D(function, bounds=(-1, 1))
-        simple(learner, goal=lambda l: l.npoints > 200)
+        simple(learner, goal=200)
         xs, ys = zip(*learner.data.items())
 
         # Make the scale huge to no get a scale doubling
@@ -374,7 +374,7 @@ def test_curvature_loss():
     loss = curvature_loss_function()
     assert loss.nth_neighbors == 1
     learner = Learner1D(f, (-1, 1), loss_per_interval=loss)
-    simple(learner, goal=lambda l: l.npoints > 100)
+    simple(learner, goal=100)
     assert learner.npoints > 100
 
 
@@ -385,7 +385,7 @@ def test_curvature_loss_vectors():
     loss = curvature_loss_function()
     assert loss.nth_neighbors == 1
     learner = Learner1D(f, (-1, 1), loss_per_interval=loss)
-    simple(learner, goal=lambda l: l.npoints > 100)
+    simple(learner, goal=100)
     assert learner.npoints > 100
 
 
@@ -398,7 +398,7 @@ def test_NaN_loss():
         return x + a**2 / (a**2 + x**2)
 
     learner = Learner1D(f, bounds=(-1, 1))
-    simple(learner, lambda l: l.npoints > 100)
+    simple(learner, 100)
 
 
 def test_inf_loss_with_missing_bounds():
@@ -408,6 +408,6 @@ def test_inf_loss_with_missing_bounds():
         loss_per_interval=curvature_loss_function(),
     )
     # must be done in parallel because otherwise the bounds will be evaluated first
-    BlockingRunner(learner, goal=lambda learner: learner.loss() < 0.01)
+    BlockingRunner(learner, goal=0.01)
 
     learner.npoints > 20

--- a/adaptive/tests/test_learnernd.py
+++ b/adaptive/tests/test_learnernd.py
@@ -33,8 +33,8 @@ def test_interior_vs_bbox_gives_same_result():
     hull = scipy.spatial.ConvexHull(control._bounds_points)
     learner = LearnerND(f, bounds=hull)
 
-    simple(control, goal=lambda l: l.loss() < 0.1)
-    simple(learner, goal=lambda l: l.loss() < 0.1)
+    simple(control, goal=0.1)
+    simple(learner, goal=0.1)
 
     assert learner.data == control.data
 
@@ -47,4 +47,4 @@ def test_vector_return_with_a_flat_layer():
     h3 = lambda xy: np.array([0 * f(xy), g(xy)])  # noqa: E731
     for function in [h1, h2, h3]:
         learner = LearnerND(function, bounds=[(-1, 1), (-1, 1)])
-        simple(learner, goal=lambda l: l.loss() < 0.1)
+        simple(learner, goal=0.1)

--- a/adaptive/tests/test_learnernd.py
+++ b/adaptive/tests/test_learnernd.py
@@ -33,8 +33,8 @@ def test_interior_vs_bbox_gives_same_result():
     hull = scipy.spatial.ConvexHull(control._bounds_points)
     learner = LearnerND(f, bounds=hull)
 
-    simple(control, goal=0.1)
-    simple(learner, goal=0.1)
+    simple(control, loss_goal=0.1)
+    simple(learner, loss_goal=0.1)
 
     assert learner.data == control.data
 
@@ -47,4 +47,4 @@ def test_vector_return_with_a_flat_layer():
     h3 = lambda xy: np.array([0 * f(xy), g(xy)])  # noqa: E731
     for function in [h1, h2, h3]:
         learner = LearnerND(function, bounds=[(-1, 1), (-1, 1)])
-        simple(learner, goal=0.1)
+        simple(learner, loss_goal=0.1)

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -103,7 +103,7 @@ def simple_run(learner, n):
             return get_goal(learner.learner)
         return get_goal(learner)
 
-    simple(learner, goal())
+    simple(learner, goal=goal())
 
 
 # Library of functions and associated learners.

--- a/adaptive/tests/test_pickling.py
+++ b/adaptive/tests/test_pickling.py
@@ -94,7 +94,7 @@ def test_serialization_for(learner_type, learner_kwargs, serializer, f):
 
     learner = learner_type(f, **learner_kwargs)
 
-    simple(learner, goal_1)
+    simple(learner, goal=goal_1)
     learner_bytes = serializer.dumps(learner)
     loss = learner.loss()
     asked = learner.ask(10)
@@ -113,5 +113,5 @@ def test_serialization_for(learner_type, learner_kwargs, serializer, f):
     # load again to undo the ask
     learner_loaded = serializer.loads(learner_bytes)
 
-    simple(learner_loaded, goal_2)
+    simple(learner_loaded, goal=goal_2)
     assert learner_loaded.npoints == 20

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -163,30 +163,30 @@ def test_default_executor():
 
 def test_auto_goal():
     learner = Learner1D(linear, (-1, 1))
-    simple(learner, auto_goal(4, learner))
+    simple(learner, auto_goal(npoints=4))
     assert learner.npoints == 4
 
     learner = Learner1D(linear, (-1, 1))
-    simple(learner, auto_goal(0.5, learner))
+    simple(learner, auto_goal(loss=0.5))
     assert learner.loss() <= 0.5
 
     learner = SequenceLearner(linear, np.linspace(-1, 1))
-    simple(learner, auto_goal(None, learner))
+    simple(learner, auto_goal(learner=learner))
     assert learner.done()
 
     learner = IntegratorLearner(linear, bounds=(0, 1), tol=0.1)
-    simple(learner, auto_goal(None, learner))
+    simple(learner, auto_goal(learner=learner))
     assert learner.done()
 
     learner = Learner1D(linear, (-1, 1))
     learner = DataSaver(learner, lambda x: x)
-    simple(learner, auto_goal(4, learner))
+    simple(learner, auto_goal(npoints=4, learner=learner))
     assert learner.npoints == 4
 
     learner1 = Learner1D(linear, (-1, 1))
     learner2 = Learner1D(linear, (-2, 2))
     balancing_learner = BalancingLearner([learner1, learner2])
-    simple(balancing_learner, auto_goal(4, balancing_learner))
+    simple(balancing_learner, auto_goal(npoints=4, learner=balancing_learner))
     assert learner1.npoints == 4 and learner2.npoints == 4
 
     learner1 = Learner1D(linear, bounds=(0, 1))
@@ -194,5 +194,5 @@ def test_auto_goal():
     learner2 = Learner1D(linear, bounds=(0, 1))
     learner2 = DataSaver(learner2, lambda x: x)
     balancing_learner = BalancingLearner([learner1, learner2])
-    simple(balancing_learner, auto_goal(10, balancing_learner))
+    simple(balancing_learner, auto_goal(npoints=10, learner=balancing_learner))
     assert learner1.npoints == 10 and learner2.npoints == 10

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -44,7 +44,7 @@ def test_simple(runner):
 
     learner = Learner1D(f, (-1, 1))
     runner(learner, 10)
-    assert len(learner.data) > 10
+    assert len(learner.data) >= 10
 
 
 @pytest.mark.parametrize("runner", runners)

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -199,6 +199,6 @@ def test_auto_goal():
 
     learner = Learner1D(linear, (-1, 1))
     t_start = time.time()
-    simple(learner, auto_goal(timedelta=1e-2, learner=learner))
+    simple(learner, auto_goal(duration=1e-2, learner=learner))
     t_end = time.time()
     assert t_end - t_start >= 1e-2

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -43,7 +43,7 @@ def test_simple(runner):
         return x
 
     learner = Learner1D(f, (-1, 1))
-    runner(learner, lambda l: l.npoints > 10)
+    runner(learner, 10)
     assert len(learner.data) > 10
 
 
@@ -152,5 +152,5 @@ def test_loky_executor(loky_executor):
 
 def test_default_executor():
     learner = Learner1D(linear, (-1, 1))
-    runner = AsyncRunner(learner, goal=lambda l: l.npoints > 10)
+    runner = AsyncRunner(learner, goal=10)
     asyncio.get_event_loop().run_until_complete(runner.task)

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -196,3 +196,9 @@ def test_auto_goal():
     balancing_learner = BalancingLearner([learner1, learner2])
     simple(balancing_learner, auto_goal(npoints=10, learner=balancing_learner))
     assert learner1.npoints == 10 and learner2.npoints == 10
+
+    learner = Learner1D(linear, (-1, 1))
+    t_start = time.time()
+    simple(learner, auto_goal(timedelta=1e-2, learner=learner))
+    t_end = time.time()
+    assert t_end - t_start >= 1e-2

--- a/adaptive/tests/test_sequence_learner.py
+++ b/adaptive/tests/test_sequence_learner.py
@@ -19,8 +19,6 @@ def test_fail_with_sequence_of_unhashable():
     # https://github.com/python-adaptive/adaptive/issues/265
     seq = [{1: 1}]  # unhashable
     learner = SequenceLearner(FailOnce(), sequence=seq)
-    runner = Runner(
-        learner, goal=SequenceLearner.done, retries=1, executor=SequentialExecutor()
-    )
+    runner = Runner(learner, retries=1, executor=SequentialExecutor())
     asyncio.get_event_loop().run_until_complete(runner.task)
     assert runner.status() == "finished"

--- a/adaptive/tests/unit/test_learnernd_integration.py
+++ b/adaptive/tests/unit/test_learnernd_integration.py
@@ -16,21 +16,21 @@ def ring_of_fire(xy, d=0.75):
 
 def test_learnerND_runs_to_10_points():
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)])
-    SimpleRunner(learner, goal=10)
+    SimpleRunner(learner, npoints_goal=10)
     assert learner.npoints == 10
 
 
 @pytest.mark.parametrize("execution_number", range(5))
 def test_learnerND_runs_to_10_points_Blocking(execution_number):
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)])
-    BlockingRunner(learner, goal=10)
+    BlockingRunner(learner, npoints_goal=10)
     assert learner.npoints >= 10
 
 
 def test_learnerND_curvature_runs_to_10_points():
     loss = curvature_loss_function()
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)], loss_per_simplex=loss)
-    SimpleRunner(learner, goal=10)
+    SimpleRunner(learner, npoints_goal=10)
     assert learner.npoints == 10
 
 
@@ -38,7 +38,7 @@ def test_learnerND_curvature_runs_to_10_points():
 def test_learnerND_curvature_runs_to_10_points_Blocking(execution_number):
     loss = curvature_loss_function()
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)], loss_per_simplex=loss)
-    BlockingRunner(learner, goal=10)
+    BlockingRunner(learner, npoints_goal=10)
     assert learner.npoints >= 10
 
 

--- a/adaptive/tests/unit/test_learnernd_integration.py
+++ b/adaptive/tests/unit/test_learnernd_integration.py
@@ -16,21 +16,21 @@ def ring_of_fire(xy, d=0.75):
 
 def test_learnerND_runs_to_10_points():
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)])
-    SimpleRunner(learner, goal=lambda l: l.npoints >= 10)
+    SimpleRunner(learner, goal=10)
     assert learner.npoints == 10
 
 
 @pytest.mark.parametrize("execution_number", range(5))
 def test_learnerND_runs_to_10_points_Blocking(execution_number):
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)])
-    BlockingRunner(learner, goal=lambda l: l.npoints >= 10)
+    BlockingRunner(learner, goal=10)
     assert learner.npoints >= 10
 
 
 def test_learnerND_curvature_runs_to_10_points():
     loss = curvature_loss_function()
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)], loss_per_simplex=loss)
-    SimpleRunner(learner, goal=lambda l: l.npoints >= 10)
+    SimpleRunner(learner, goal=10)
     assert learner.npoints == 10
 
 
@@ -38,7 +38,7 @@ def test_learnerND_curvature_runs_to_10_points():
 def test_learnerND_curvature_runs_to_10_points_Blocking(execution_number):
     loss = curvature_loss_function()
     learner = LearnerND(ring_of_fire, bounds=[(-1, 1), (-1, 1)], loss_per_simplex=loss)
-    BlockingRunner(learner, goal=lambda l: l.npoints >= 10)
+    BlockingRunner(learner, goal=10)
     assert learner.npoints >= 10
 
 

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -83,7 +83,8 @@ def load(fname: str, compress: bool = True) -> Any:
 
 def copy_docstring_from(other: Callable) -> Callable:
     def decorator(method):
-        return functools.wraps(other)(method)
+        method.__doc__ = other.__doc__
+        return method
 
     return decorator
 

--- a/docs/logo.py
+++ b/docs/logo.py
@@ -22,7 +22,7 @@ def create_and_run_learner():
         return x + np.exp(-((x**2 + y**2 - 0.75**2) ** 2) / a**4)
 
     learner = adaptive.Learner2D(ring, bounds=[(-1, 1), (-1, 1)])
-    adaptive.runner.simple(learner, goal=lambda l: l.loss() < 0.01)
+    adaptive.runner.simple(learner, goal=0.01)
     return learner
 
 

--- a/docs/logo.py
+++ b/docs/logo.py
@@ -22,7 +22,7 @@ def create_and_run_learner():
         return x + np.exp(-((x**2 + y**2 - 0.75**2) ** 2) / a**4)
 
     learner = adaptive.Learner2D(ring, bounds=[(-1, 1), (-1, 1)])
-    adaptive.runner.simple(learner, goal=0.01)
+    adaptive.runner.simple(learner, loss_goal=0.01)
     return learner
 
 

--- a/docs/source/algorithms_and_examples.md
+++ b/docs/source/algorithms_and_examples.md
@@ -102,7 +102,7 @@ def plot_loss_interval(learner):
 
 
 def plot(learner, npoints):
-    adaptive.runner.simple(learner, lambda l: l.npoints == npoints)
+    adaptive.runner.simple(learner, npoints_goal= npoints)
     return (learner.plot() * plot_loss_interval(learner))[:, -1.1:1.1]
 
 
@@ -132,7 +132,7 @@ def ring(xy):
 
 
 def plot(learner, npoints):
-    adaptive.runner.simple(learner, lambda l: l.npoints == npoints)
+    adaptive.runner.simple(learner, npoints_goal=npoints)
     learner2 = adaptive.Learner2D(ring, bounds=learner.bounds)
     xs = ys = np.linspace(*learner.bounds[0], int(learner.npoints**0.5))
     xys = list(itertools.product(xs, ys))
@@ -168,7 +168,7 @@ learner = adaptive.AverageLearner(g, atol=None, rtol=0.01)
 
 
 def plot(learner, npoints):
-    adaptive.runner.simple(learner, lambda l: l.npoints == npoints)
+    adaptive.runner.simple(learner, npoints_goal=npoints)
     return learner.plot().relabel(f"loss={learner.loss():.2f}")
 
 
@@ -191,7 +191,7 @@ def sphere(xyz):
 
 
 learner = adaptive.LearnerND(sphere, bounds=[(-1, 1), (-1, 1), (-1, 1)])
-adaptive.runner.simple(learner, lambda l: l.npoints == 5000)
+adaptive.runner.simple(learner, npoints_goal=5000)
 
 fig = learner.plot_3D(return_fig=True)
 

--- a/docs/source/logo.md
+++ b/docs/source/logo.md
@@ -110,7 +110,7 @@ def create_and_run_learner():
         return x + np.exp(-((x**2 + y**2 - 0.75**2) ** 2) / a**4)
 
     learner = adaptive.Learner2D(ring, bounds=[(-1, 1), (-1, 1)])
-    adaptive.runner.simple(learner, goal=0.005)
+    adaptive.runner.simple(learner, loss_goal=0.005)
     return learner
 
 

--- a/docs/source/logo.md
+++ b/docs/source/logo.md
@@ -110,7 +110,7 @@ def create_and_run_learner():
         return x + np.exp(-((x**2 + y**2 - 0.75**2) ** 2) / a**4)
 
     learner = adaptive.Learner2D(ring, bounds=[(-1, 1), (-1, 1)])
-    adaptive.runner.simple(learner, goal=lambda l: l.loss() < 0.005)
+    adaptive.runner.simple(learner, goal=0.005)
     return learner
 
 

--- a/docs/source/reference/adaptive.runner.extras.md
+++ b/docs/source/reference/adaptive.runner.extras.md
@@ -6,10 +6,9 @@ Runners allow you to specify the stopping criterion by providing
 a `goal` as a function that takes the learner and returns a boolean: `False`
 for "continue running" and `True` for "stop". This gives you a lot of flexibility
 for defining your own stopping conditions, however we also provide some common
-stopping conditions as a convenience. The `adaptive.runner.auto_goal` will
-automatically create a goal based on simple input types, e.g., an int means
-at least that many points are required and a float means that the loss has
-to become lower or equal to that float.
+stopping conditions as a convenience. For example, to continue until the loss is below a threshold `x`,
+you may specify `loss_goal=x`. Similarly, to continue until `n` points have been sampled, you may
+specify `npoints_goal=n`. See the Runner docstring for details.
 
 ```{eval-rst}
 .. autofunction:: adaptive.runner.auto_goal

--- a/docs/source/reference/adaptive.runner.extras.md
+++ b/docs/source/reference/adaptive.runner.extras.md
@@ -6,7 +6,14 @@ Runners allow you to specify the stopping criterion by providing
 a `goal` as a function that takes the learner and returns a boolean: `False`
 for "continue running" and `True` for "stop". This gives you a lot of flexibility
 for defining your own stopping conditions, however we also provide some common
-stopping conditions as a convenience.
+stopping conditions as a convenience. The `adaptive.runner.auto_goal` will
+automatically create a goal based on simple input types, e.g., an int means
+at least that many points are required and a float means that the loss has
+to become lower or equal to that float.
+
+```{eval-rst}
+.. autofunction:: adaptive.runner.auto_goal
+```
 
 ```{eval-rst}
 .. autofunction:: adaptive.runner.stop_after

--- a/docs/source/tutorial/tutorial.AverageLearner.md
+++ b/docs/source/tutorial/tutorial.AverageLearner.md
@@ -46,7 +46,7 @@ def g(n):
 ```{code-cell} ipython3
 learner = adaptive.AverageLearner(g, atol=None, rtol=0.01)
 # `loss < 1.0` means that we reached the `rtol` or `atol`
-runner = adaptive.Runner(learner, goal=1.0)
+runner = adaptive.Runner(learner, loss_goal=1.0)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.AverageLearner.md
+++ b/docs/source/tutorial/tutorial.AverageLearner.md
@@ -45,8 +45,8 @@ def g(n):
 
 ```{code-cell} ipython3
 learner = adaptive.AverageLearner(g, atol=None, rtol=0.01)
-# `loss < 1` means that we reached the `rtol` or `atol`
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 1)
+# `loss < 1.0` means that we reached the `rtol` or `atol`
+runner = adaptive.Runner(learner, goal=1.0)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.BalancingLearner.md
+++ b/docs/source/tutorial/tutorial.BalancingLearner.md
@@ -46,7 +46,7 @@ learners = [
 ]
 
 bal_learner = adaptive.BalancingLearner(learners)
-runner = adaptive.Runner(bal_learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(bal_learner, goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -86,7 +86,7 @@ learner = adaptive.BalancingLearner.from_product(
     jacobi, adaptive.Learner1D, dict(bounds=(0, 1)), combos
 )
 
-runner = adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.BlockingRunner(learner, goal=0.01)
 
 # The `cdims` will automatically be set when using `from_product`, so
 # `plot()` will return a HoloMap with correctly labeled sliders.

--- a/docs/source/tutorial/tutorial.BalancingLearner.md
+++ b/docs/source/tutorial/tutorial.BalancingLearner.md
@@ -46,7 +46,7 @@ learners = [
 ]
 
 bal_learner = adaptive.BalancingLearner(learners)
-runner = adaptive.Runner(bal_learner, goal=0.01)
+runner = adaptive.Runner(bal_learner, loss_goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -86,7 +86,7 @@ learner = adaptive.BalancingLearner.from_product(
     jacobi, adaptive.Learner1D, dict(bounds=(0, 1)), combos
 )
 
-runner = adaptive.BlockingRunner(learner, goal=0.01)
+runner = adaptive.BlockingRunner(learner, loss_goal=0.01)
 
 # The `cdims` will automatically be set when using `from_product`, so
 # `plot()` will return a HoloMap with correctly labeled sliders.

--- a/docs/source/tutorial/tutorial.DataSaver.md
+++ b/docs/source/tutorial/tutorial.DataSaver.md
@@ -55,7 +55,7 @@ learner = adaptive.DataSaver(_learner, arg_picker=itemgetter("y"))
 `learner.learner` is the original learner, so `learner.learner.loss()` will call the correct loss method.
 
 ```{code-cell} ipython3
-runner = adaptive.Runner(learner, goal=lambda l: l.learner.loss() < 0.1)
+runner = adaptive.Runner(learner, loss_goal=0.1)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.IntegratorLearner.md
+++ b/docs/source/tutorial/tutorial.IntegratorLearner.md
@@ -61,7 +61,7 @@ learner = adaptive.IntegratorLearner(f24, bounds=(0, 3), tol=1e-8)
 # *this* process only. This means we don't pay
 # the overhead of evaluating the function in another process.
 runner = adaptive.Runner(
-    learner, executor=SequentialExecutor(), goal=lambda l: l.done()
+    learner, executor=SequentialExecutor()
 )
 ```
 
@@ -75,7 +75,7 @@ await runner.task  # This is not needed in a notebook environment!
 runner.live_info()
 ```
 
-Now we could do the live plotting again, but lets just wait untill the
+Now we could do the live plotting again, but let's just wait until the
 runner is done.
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -124,7 +124,7 @@ The `Learner1D` can be used for such functions:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f_levels, bounds=(-1, 1))
-runner = adaptive.Runner(learner, loss_goal=0.01)
+runner = adaptive.Runner(learner, loss_goal=0.01)  # continue until `learner.loss()<=1`
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -63,8 +63,8 @@ On Windows systems the runner will use a {class}`loky.get_reusable_executor`.
 A {class}`~concurrent.futures.ProcessPoolExecutor` cannot be used on Windows for reasons.
 
 ```{code-cell} ipython3
-# The end condition is when the "loss" is less than 0.1. In the context of the
-# 1D learner this means that we will resolve features in 'func' with width 0.1 or wider.
+# The end condition is when the "loss" is less than 0.01. In the context of the
+# 1D learner this means that we will resolve features in 'func' with width 0.01 or wider.
 runner = adaptive.Runner(learner, goal=0.01)
 ```
 

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -187,7 +187,7 @@ learner_h = adaptive.Learner1D(sin_exp, (-1, 1), loss_per_interval=uniform_loss)
 learner_1 = adaptive.Learner1D(sin_exp, (-1, 1), loss_per_interval=default_loss)
 learner_2 = adaptive.Learner1D(sin_exp, (-1, 1), loss_per_interval=curvature_loss)
 
-npoints_goal = lambda l: l.npoints >= 100
+npoints_goal = 100
 # adaptive.runner.simple is a non parallel blocking runner.
 adaptive.runner.simple(learner_h, goal=npoints_goal)
 adaptive.runner.simple(learner_1, goal=npoints_goal)

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -65,7 +65,7 @@ A {class}`~concurrent.futures.ProcessPoolExecutor` cannot be used on Windows for
 ```{code-cell} ipython3
 # The end condition is when the "loss" is less than 0.1. In the context of the
 # 1D learner this means that we will resolve features in 'func' with width 0.1 or wider.
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -124,7 +124,7 @@ The `Learner1D` can be used for such functions:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f_levels, bounds=(-1, 1))
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -156,7 +156,7 @@ from adaptive.learner.learner1D import (
 
 curvature_loss = curvature_loss_function()
 learner = adaptive.Learner1D(f, bounds=(-1, 1), loss_per_interval=curvature_loss)
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, goal=0.01)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -65,7 +65,7 @@ A {class}`~concurrent.futures.ProcessPoolExecutor` cannot be used on Windows for
 ```{code-cell} ipython3
 # The end condition is when the "loss" is less than 0.01. In the context of the
 # 1D learner this means that we will resolve features in 'func' with width 0.01 or wider.
-runner = adaptive.Runner(learner, goal=0.01)
+runner = adaptive.Runner(learner, loss_goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -124,7 +124,7 @@ The `Learner1D` can be used for such functions:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f_levels, bounds=(-1, 1))
-runner = adaptive.Runner(learner, goal=0.01)
+runner = adaptive.Runner(learner, loss_goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -156,7 +156,7 @@ from adaptive.learner.learner1D import (
 
 curvature_loss = curvature_loss_function()
 learner = adaptive.Learner1D(f, bounds=(-1, 1), loss_per_interval=curvature_loss)
-runner = adaptive.Runner(learner, goal=0.01)
+runner = adaptive.Runner(learner, loss_goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -187,11 +187,10 @@ learner_h = adaptive.Learner1D(sin_exp, (-1, 1), loss_per_interval=uniform_loss)
 learner_1 = adaptive.Learner1D(sin_exp, (-1, 1), loss_per_interval=default_loss)
 learner_2 = adaptive.Learner1D(sin_exp, (-1, 1), loss_per_interval=curvature_loss)
 
-npoints_goal = 100
 # adaptive.runner.simple is a non parallel blocking runner.
-adaptive.runner.simple(learner_h, goal=npoints_goal)
-adaptive.runner.simple(learner_1, goal=npoints_goal)
-adaptive.runner.simple(learner_2, goal=npoints_goal)
+adaptive.runner.simple(learner_h, npoints_goal=100)
+adaptive.runner.simple(learner_1, npoints_goal=100)
+adaptive.runner.simple(learner_2, npoints_goal=100)
 
 (
     learner_h.plot().relabel("homogeneous")

--- a/docs/source/tutorial/tutorial.Learner1D.md
+++ b/docs/source/tutorial/tutorial.Learner1D.md
@@ -124,7 +124,7 @@ The `Learner1D` can be used for such functions:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f_levels, bounds=(-1, 1))
-runner = adaptive.Runner(learner, loss_goal=0.01)  # continue until `learner.loss()<=1`
+runner = adaptive.Runner(learner, loss_goal=0.01)  # continue until `learner.loss()<=0.01`
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.Learner2D.md
+++ b/docs/source/tutorial/tutorial.Learner2D.md
@@ -46,7 +46,7 @@ learner = adaptive.Learner2D(ring, bounds=[(-1, 1), (-1, 1)])
 ```
 
 ```{code-cell} ipython3
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, goal=0.01)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.Learner2D.md
+++ b/docs/source/tutorial/tutorial.Learner2D.md
@@ -46,7 +46,7 @@ learner = adaptive.Learner2D(ring, bounds=[(-1, 1), (-1, 1)])
 ```
 
 ```{code-cell} ipython3
-runner = adaptive.Runner(learner, goal=0.01)
+runner = adaptive.Runner(learner, loss_goal=0.01)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.LearnerND.md
+++ b/docs/source/tutorial/tutorial.LearnerND.md
@@ -50,7 +50,7 @@ def sphere(xyz):
 
 
 learner = adaptive.LearnerND(sphere, bounds=[(-1, 1), (-1, 1), (-1, 1)])
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 1e-3)
+runner = adaptive.Runner(learner, goal=1e-3)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.LearnerND.md
+++ b/docs/source/tutorial/tutorial.LearnerND.md
@@ -123,7 +123,7 @@ b = [(-1, -1, -1), (-1, 1, -1), (-1, -1, 1), (-1, 1, 1), (1, 1, -1), (1, -1, -1)
 hull = scipy.spatial.ConvexHull(b)
 
 learner = adaptive.LearnerND(f, hull)
-adaptive.BlockingRunner(learner, goal=lambda l: l.npoints > 2000)
+adaptive.BlockingRunner(learner, goal=2000)
 
 learner.plot_isosurface(-0.5)
 ```

--- a/docs/source/tutorial/tutorial.LearnerND.md
+++ b/docs/source/tutorial/tutorial.LearnerND.md
@@ -50,7 +50,7 @@ def sphere(xyz):
 
 
 learner = adaptive.LearnerND(sphere, bounds=[(-1, 1), (-1, 1), (-1, 1)])
-runner = adaptive.Runner(learner, goal=1e-3)
+runner = adaptive.Runner(learner, loss_goal=1e-3)
 ```
 
 ```{code-cell} ipython3
@@ -123,7 +123,7 @@ b = [(-1, -1, -1), (-1, 1, -1), (-1, -1, 1), (-1, 1, 1), (1, 1, -1), (1, -1, -1)
 hull = scipy.spatial.ConvexHull(b)
 
 learner = adaptive.LearnerND(f, hull)
-adaptive.BlockingRunner(learner, goal=2000)
+adaptive.BlockingRunner(learner, npoints_goal=2000)
 
 learner.plot_isosurface(-0.5)
 ```

--- a/docs/source/tutorial/tutorial.SKOptLearner.md
+++ b/docs/source/tutorial/tutorial.SKOptLearner.md
@@ -47,7 +47,7 @@ learner = adaptive.SKOptLearner(
     acq_func="gp_hedge",
     acq_optimizer="lbfgs",
 )
-runner = adaptive.Runner(learner, ntasks=1, goal=40)
+runner = adaptive.Runner(learner, ntasks=1, npoints_goal=40)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.SKOptLearner.md
+++ b/docs/source/tutorial/tutorial.SKOptLearner.md
@@ -47,7 +47,7 @@ learner = adaptive.SKOptLearner(
     acq_func="gp_hedge",
     acq_optimizer="lbfgs",
 )
-runner = adaptive.Runner(learner, ntasks=1, goal=lambda l: l.npoints > 40)
+runner = adaptive.Runner(learner, ntasks=1, goal=40)
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.SequenceLearner.md
+++ b/docs/source/tutorial/tutorial.SequenceLearner.md
@@ -42,8 +42,8 @@ def f(x):
 seq = np.linspace(-15, 15, 1000)
 learner = SequenceLearner(f, seq)
 
-runner = adaptive.Runner(learner, SequenceLearner.done)
-# that goal is same as `lambda learner: learner.done()`
+runner = adaptive.Runner(learner)
+# not providing a goal is same as `lambda learner: learner.done()`
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/tutorial/tutorial.advanced-topics.md
+++ b/docs/source/tutorial/tutorial.advanced-topics.md
@@ -90,7 +90,7 @@ def slow_f(x):
 
 
 learner = adaptive.Learner1D(slow_f, bounds=[0, 1])
-runner = adaptive.Runner(learner, goal=lambda l: l.npoints > 100)
+runner = adaptive.Runner(learner, goal=100)
 runner.start_periodic_saving(
     save_kwargs=dict(fname="data/periodic_example.p"), interval=6
 )

--- a/docs/source/tutorial/tutorial.advanced-topics.md
+++ b/docs/source/tutorial/tutorial.advanced-topics.md
@@ -51,7 +51,7 @@ learner = adaptive.Learner1D(f, bounds=(-1, 1))
 control = adaptive.Learner1D(f, bounds=(-1, 1))
 
 # Let's only run the learner
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -134,7 +134,7 @@ The simplest way to accomplish this is to use {class}`adaptive.BlockingRunner`:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.01)
+adaptive.BlockingRunner(learner, goal=0.01)
 # This will only get run after the runner has finished
 learner.plot()
 ```
@@ -155,7 +155,7 @@ The simplest way is to use {class}`adaptive.runner.simple` to run your learner:
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
 
 # blocks until completion
-adaptive.runner.simple(learner, goal=lambda l: l.loss() < 0.01)
+adaptive.runner.simple(learner, goal=0.01)
 
 learner.plot()
 ```
@@ -169,7 +169,7 @@ from adaptive.runner import SequentialExecutor
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
 runner = adaptive.Runner(
-    learner, executor=SequentialExecutor(), goal=lambda l: l.loss() < 0.01
+    learner, executor=SequentialExecutor(), goal=0.01
 )
 ```
 
@@ -292,7 +292,7 @@ One way to inspect runners is to instantiate one with `log=True`:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01, log=True)
+runner = adaptive.Runner(learner, goal=0.01, log=True)
 ```
 
 ```{code-cell} ipython3
@@ -351,7 +351,7 @@ async def time(runner):
 ioloop = asyncio.get_event_loop()
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, goal=0.01)
 
 timer = ioloop.create_task(time(runner))
 ```
@@ -462,7 +462,7 @@ def f(x):
 
 learner = adaptive.Learner1D(f, (-1, 1))
 
-adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.1)
+adaptive.BlockingRunner(learner, goal=0.1)
 ```
 
 If you use `asyncio` already in your script and want to integrate `adaptive` into it, then you can use the default {class}`~adaptive.Runner` as you would from a notebook.

--- a/docs/source/tutorial/tutorial.advanced-topics.md
+++ b/docs/source/tutorial/tutorial.advanced-topics.md
@@ -51,7 +51,7 @@ learner = adaptive.Learner1D(f, bounds=(-1, 1))
 control = adaptive.Learner1D(f, bounds=(-1, 1))
 
 # Let's only run the learner
-runner = adaptive.Runner(learner, goal=0.01)
+runner = adaptive.Runner(learner, loss_goal=0.01)
 ```
 
 ```{code-cell} ipython3
@@ -90,7 +90,7 @@ def slow_f(x):
 
 
 learner = adaptive.Learner1D(slow_f, bounds=[0, 1])
-runner = adaptive.Runner(learner, goal=100)
+runner = adaptive.Runner(learner, npoints_goal=100)
 runner.start_periodic_saving(
     save_kwargs=dict(fname="data/periodic_example.p"), interval=6
 )
@@ -134,7 +134,7 @@ The simplest way to accomplish this is to use {class}`adaptive.BlockingRunner`:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-adaptive.BlockingRunner(learner, goal=0.01)
+adaptive.BlockingRunner(learner, loss_goal=0.01)
 # This will only get run after the runner has finished
 learner.plot()
 ```
@@ -155,7 +155,7 @@ The simplest way is to use {class}`adaptive.runner.simple` to run your learner:
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
 
 # blocks until completion
-adaptive.runner.simple(learner, goal=0.01)
+adaptive.runner.simple(learner, loss_goal=0.01)
 
 learner.plot()
 ```
@@ -169,7 +169,7 @@ from adaptive.runner import SequentialExecutor
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
 runner = adaptive.Runner(
-    learner, executor=SequentialExecutor(), goal=0.01
+    learner, executor=SequentialExecutor(), loss_goal=0.01
 )
 ```
 
@@ -292,7 +292,7 @@ One way to inspect runners is to instantiate one with `log=True`:
 
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, goal=0.01, log=True)
+runner = adaptive.Runner(learner, loss_goal=0.01, log=True)
 ```
 
 ```{code-cell} ipython3
@@ -351,7 +351,7 @@ async def time(runner):
 ioloop = asyncio.get_event_loop()
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, goal=0.01)
+runner = adaptive.Runner(learner, loss_goal=0.01)
 
 timer = ioloop.create_task(time(runner))
 ```
@@ -436,7 +436,7 @@ To run the adaptive evaluation we provide the asynchronous function to the `lear
 ```{code-cell} ipython3
 learner = adaptive.Learner1D(f_parallel, bounds=(-3.5, 3.5))
 
-runner = adaptive.AsyncRunner(learner, goal=lambda l: l.loss() < 0.01, ntasks=20)
+runner = adaptive.AsyncRunner(learner, loss_goal=0.01, ntasks=20)
 ```
 
 Finally we await for the runner to finish, and then plot the result.
@@ -462,7 +462,7 @@ def f(x):
 
 learner = adaptive.Learner1D(f, (-1, 1))
 
-adaptive.BlockingRunner(learner, goal=0.1)
+adaptive.BlockingRunner(learner, loss_goal=0.1)
 ```
 
 If you use `asyncio` already in your script and want to integrate `adaptive` into it, then you can use the default {class}`~adaptive.Runner` as you would from a notebook.

--- a/docs/source/tutorial/tutorial.custom_loss.md
+++ b/docs/source/tutorial/tutorial.custom_loss.md
@@ -74,7 +74,7 @@ def f_divergent_1d(x):
 learner = adaptive.Learner1D(
     f_divergent_1d, (-1, 1), loss_per_interval=uniform_sampling_1d
 )
-runner = adaptive.BlockingRunner(learner, goal=0.01)
+runner = adaptive.BlockingRunner(learner, loss_goal=0.01)
 learner.plot().select(y=(0, 10000))
 ```
 
@@ -99,7 +99,7 @@ learner = adaptive.Learner2D(
 )
 
 # this takes a while, so use the async Runner so we know *something* is happening
-runner = adaptive.Runner(learner, goal= l.loss() < 0.03 or l.npoints > 1000)
+runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.03 or l.npoints > 1000)
 ```
 
 ```{code-cell} ipython3
@@ -154,7 +154,7 @@ def resolution_loss_function(min_distance=0, max_distance=1):
 loss = resolution_loss_function(min_distance=0.01)
 
 learner = adaptive.Learner2D(f_divergent_2d, [(-1, 1), (-1, 1)], loss_per_triangle=loss)
-runner = adaptive.BlockingRunner(learner, goal=0.02)
+runner = adaptive.BlockingRunner(learner, loss_goal=0.02)
 learner.plot(tri_alpha=0.3).relabel("1 / (x^2 + y^2) in log scale").opts(
     hv.opts.EdgePaths(color="w"), hv.opts.Image(logz=True, colorbar=True)
 )

--- a/docs/source/tutorial/tutorial.custom_loss.md
+++ b/docs/source/tutorial/tutorial.custom_loss.md
@@ -74,7 +74,7 @@ def f_divergent_1d(x):
 learner = adaptive.Learner1D(
     f_divergent_1d, (-1, 1), loss_per_interval=uniform_sampling_1d
 )
-runner = adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.BlockingRunner(learner, goal=0.01)
 learner.plot().select(y=(0, 10000))
 ```
 
@@ -99,7 +99,7 @@ learner = adaptive.Learner2D(
 )
 
 # this takes a while, so use the async Runner so we know *something* is happening
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.03 or l.npoints > 1000)
+runner = adaptive.Runner(learner, goal= l.loss() < 0.03 or l.npoints > 1000)
 ```
 
 ```{code-cell} ipython3
@@ -154,7 +154,7 @@ def resolution_loss_function(min_distance=0, max_distance=1):
 loss = resolution_loss_function(min_distance=0.01)
 
 learner = adaptive.Learner2D(f_divergent_2d, [(-1, 1), (-1, 1)], loss_per_triangle=loss)
-runner = adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.02)
+runner = adaptive.BlockingRunner(learner, goal=0.02)
 learner.plot(tri_alpha=0.3).relabel("1 / (x^2 + y^2) in log scale").opts(
     hv.opts.EdgePaths(color="w"), hv.opts.Image(logz=True, colorbar=True)
 )

--- a/docs/source/tutorial/tutorial.parallelism.md
+++ b/docs/source/tutorial/tutorial.parallelism.md
@@ -24,7 +24,7 @@ from concurrent.futures import ProcessPoolExecutor
 executor = ProcessPoolExecutor(max_workers=4)
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, executor=executor, goal=lambda l: l.loss() < 0.05)
+runner = adaptive.Runner(learner, executor=executor, goal=0.05)
 runner.live_info()
 runner.live_plot(update_interval=0.1)
 ```
@@ -37,7 +37,7 @@ import ipyparallel
 client = ipyparallel.Client()  # You will need to start an `ipcluster` to make this work
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, executor=client, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, executor=client, goal=0.01)
 runner.live_info()
 runner.live_plot()
 ```
@@ -52,7 +52,7 @@ import distributed
 client = distributed.Client()
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, executor=client, goal=lambda l: l.loss() < 0.01)
+runner = adaptive.Runner(learner, executor=client, goal=0.01)
 runner.live_info()
 runner.live_plot(update_interval=0.1)
 ```
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         learner,
         executor=MPIPoolExecutor(),
         shutdown_executor=True,
-        goal=lambda l: l.loss() < 0.01,
+        goal=0.01,
     )
 
     # periodically save the data (in case the job dies)
@@ -132,6 +132,6 @@ ex = get_reusable_executor()
 f = lambda x: x
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
 
-runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01, executor=ex)
+runner = adaptive.Runner(learner, goal=0.01, executor=ex)
 runner.live_info()
 ```

--- a/docs/source/tutorial/tutorial.parallelism.md
+++ b/docs/source/tutorial/tutorial.parallelism.md
@@ -24,7 +24,7 @@ from concurrent.futures import ProcessPoolExecutor
 executor = ProcessPoolExecutor(max_workers=4)
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, executor=executor, goal=0.05)
+runner = adaptive.Runner(learner, executor=executor, loss_goal=0.05)
 runner.live_info()
 runner.live_plot(update_interval=0.1)
 ```
@@ -37,7 +37,7 @@ import ipyparallel
 client = ipyparallel.Client()  # You will need to start an `ipcluster` to make this work
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, executor=client, goal=0.01)
+runner = adaptive.Runner(learner, executor=client, loss_goal=0.01)
 runner.live_info()
 runner.live_plot()
 ```
@@ -52,7 +52,7 @@ import distributed
 client = distributed.Client()
 
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
-runner = adaptive.Runner(learner, executor=client, goal=0.01)
+runner = adaptive.Runner(learner, executor=client, loss_goal=0.01)
 runner.live_info()
 runner.live_plot(update_interval=0.1)
 ```
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         learner,
         executor=MPIPoolExecutor(),
         shutdown_executor=True,
-        goal=0.01,
+        loss_goal=0.01,
     )
 
     # periodically save the data (in case the job dies)
@@ -132,6 +132,6 @@ ex = get_reusable_executor()
 f = lambda x: x
 learner = adaptive.Learner1D(f, bounds=(-1, 1))
 
-runner = adaptive.Runner(learner, goal=0.01, executor=ex)
+runner = adaptive.Runner(learner, loss_goal=0.01, executor=ex)
 runner.live_info()
 ```

--- a/example-notebook.ipynb
+++ b/example-notebook.ipynb
@@ -106,7 +106,7 @@
    "source": [
     "# The end condition is when the \"loss\" is less than 0.01. In the context of the\n",
     "# 1D learner this means that we will resolve features in 'func' with width 0.01 or wider.\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.Runner(learner, goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.Runner(learner, goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -279,7 +279,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.AverageLearner(g, atol=None, rtol=0.01)\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 2)\n",
+    "runner = adaptive.Runner(learner, goal=2.0)\n",
     "runner.live_info()"
    ]
   },
@@ -465,7 +465,7 @@
     "# We use a SequentialExecutor, which runs the function to be learned in *this* process only.\n",
     "# This means we don't pay the overhead of evaluating the function in another process.\n",
     "executor = SequentialExecutor()\n",
-    "runner = adaptive.Runner(learner, executor=executor, goal=lambda l: l.done())\n",
+    "runner = adaptive.Runner(learner, executor=executor)\n",
     "runner.live_info()"
    ]
   },
@@ -535,7 +535,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.Learner1D(f_levels, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.Runner(learner, goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -564,7 +564,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this step takes a lot of time, it will finish at about 3300 points, which can take up to 6 minutes\n",
     "def sphere(xyz):\n",
     "    x, y, z = xyz\n",
     "    a = 0.4\n",
@@ -572,7 +571,7 @@
     "\n",
     "\n",
     "learner = adaptive.LearnerND(sphere, bounds=[(-1, 1), (-1, 1), (-1, 1)])\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.npoints > 2000)\n",
+    "runner = adaptive.Runner(learner, goal=2000)\n",
     "runner.live_info()"
    ]
   },
@@ -675,13 +674,15 @@
     "\n",
     "\n",
     "def f_divergent_1d(x):\n",
+    "    if x == 0:\n",
+    "        return np.inf\n",
     "    return 1 / x**2\n",
     "\n",
     "\n",
     "learner = adaptive.Learner1D(\n",
     "    f_divergent_1d, (-1, 1), loss_per_interval=uniform_sampling_1d\n",
     ")\n",
-    "runner = adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.BlockingRunner(learner, goal=0.01)\n",
     "learner.plot().select(y=(0, 10000))"
    ]
   },
@@ -718,7 +719,7 @@
     ")\n",
     "\n",
     "# this takes a while, so use the async Runner so we know *something* is happening\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.02)\n",
+    "runner = adaptive.Runner(learner, goal=0.02)\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.2, plotter=plot_logz)"
    ]
@@ -780,7 +781,7 @@
     "loss = partial(resolution_loss, min_distance=0.01)\n",
     "\n",
     "learner = adaptive.Learner2D(f_divergent_2d, [(-1, 1), (-1, 1)], loss_per_triangle=loss)\n",
-    "runner = adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.02)\n",
+    "runner = adaptive.BlockingRunner(learner, goal=0.02)\n",
     "plot_logz(learner)"
    ]
   },
@@ -826,7 +827,7 @@
     "]\n",
     "\n",
     "bal_learner = adaptive.BalancingLearner(learners)\n",
-    "runner = adaptive.Runner(bal_learner, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.Runner(bal_learner, goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -870,7 +871,7 @@
     "    jacobi, adaptive.Learner1D, dict(bounds=(0, 1)), combos\n",
     ")\n",
     "\n",
-    "runner = adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.BlockingRunner(learner, goal=0.01)\n",
     "\n",
     "# The `cdims` will automatically be set when using `from_product`, so\n",
     "# `plot()` will return a HoloMap with correctly labeled sliders.\n",
@@ -935,7 +936,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runner = adaptive.Runner(learner, goal=lambda l: l.learner.loss() < 0.05)\n",
+    "runner = adaptive.Runner(learner, goal=0.05)\n",
     "runner.live_info()"
    ]
   },
@@ -1005,7 +1006,7 @@
     "    acq_func=\"gp_hedge\",\n",
     "    acq_optimizer=\"lbfgs\",\n",
     ")\n",
-    "runner = adaptive.Runner(learner, ntasks=1, goal=lambda l: l.npoints > 40)\n",
+    "runner = adaptive.Runner(learner, ntasks=1, goal=40)\n",
     "runner.live_info()"
    ]
   },
@@ -1063,7 +1064,7 @@
     "executor = ProcessPoolExecutor(max_workers=4)\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, executor=executor, goal=lambda l: l.loss() < 0.05)\n",
+    "runner = adaptive.Runner(learner, executor=executor, goal=0.05)\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.1)"
    ]
@@ -1086,7 +1087,7 @@
     "client = ipyparallel.Client()  # You will need to start an `ipcluster` to make this work\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, executor=client, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.Runner(learner, executor=client, goal=0.01)\n",
     "runner.live_info()\n",
     "runner.live_plot()"
    ]
@@ -1111,7 +1112,7 @@
     "client = distributed.Client()\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, executor=client, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.Runner(learner, executor=client, goal=0.01)\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.1)"
    ]
@@ -1163,7 +1164,7 @@
     "control = adaptive.Learner1D(partial(peak, wait=False), bounds=(-1, 1))\n",
     "\n",
     "# Let's only run the learner\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.01)\n",
+    "runner = adaptive.Runner(learner, goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -1239,7 +1240,7 @@
     "\n",
     "\n",
     "learner = adaptive.Learner1D(slow_f, bounds=[0, 1])\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.npoints > 100)\n",
+    "runner = adaptive.Runner(learner, goal=100)\n",
     "\n",
     "runner.start_periodic_saving(\n",
     "    save_kwargs=dict(fname=\"data/periodic_example.p\"), interval=6\n",
@@ -1335,7 +1336,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.Learner1D(partial(peak, wait=False), bounds=(-1, 1))\n",
-    "adaptive.BlockingRunner(learner, goal=lambda l: l.loss() < 0.005)\n",
+    "adaptive.BlockingRunner(learner, goal=0.005)\n",
     "# This will only get run after the runner has finished\n",
     "learner.plot()"
    ]
@@ -1369,7 +1370,7 @@
     "learner = adaptive.Learner1D(partial(peak, wait=False), bounds=(-1, 1))\n",
     "\n",
     "# blocks until completion\n",
-    "adaptive.runner.simple(learner, goal=lambda l: l.loss() < 0.002)\n",
+    "adaptive.runner.simple(learner, goal=0.002)\n",
     "\n",
     "learner.plot()"
    ]
@@ -1394,7 +1395,7 @@
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
     "\n",
     "runner = adaptive.Runner(\n",
-    "    learner, executor=SequentialExecutor(), goal=lambda l: l.loss() < 0.002\n",
+    "    learner, executor=SequentialExecutor(), goal=0.002\n",
     ")\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.1)"
@@ -1543,7 +1544,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.1, log=True)\n",
+    "runner = adaptive.Runner(learner, goal=0.1, log=True)\n",
     "runner.live_info()"
    ]
   },
@@ -1628,7 +1629,7 @@
     "ioloop = asyncio.get_event_loop()\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, goal=lambda l: l.loss() < 0.1)\n",
+    "runner = adaptive.Runner(learner, goal=0.1)\n",
     "\n",
     "timer = ioloop.create_task(time(runner))\n",
     "runner.live_info()"
@@ -1667,7 +1668,7 @@
     "\n",
     "learner = adaptive.Learner1D(peak, (-1, 1))\n",
     "\n",
-    "adaptive.BlockingRunner(learner, goal=lambda: l: l.loss() < 0.1)\n",
+    "adaptive.BlockingRunner(learner, goal=0.1)\n",
     "```\n",
     "\n",
     "If you use `asyncio` already in your script and want to integrate `adaptive` into it, then you can use the default `Runner` as you would from a notebook. If you want to wait for the runner to finish, then you can simply\n",

--- a/example-notebook.ipynb
+++ b/example-notebook.ipynb
@@ -106,7 +106,7 @@
    "source": [
     "# The end condition is when the \"loss\" is less than 0.01. In the context of the\n",
     "# 1D learner this means that we will resolve features in 'func' with width 0.01 or wider.\n",
-    "runner = adaptive.Runner(learner, goal=0.01)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runner = adaptive.Runner(learner, goal=0.01)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -279,7 +279,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.AverageLearner(g, atol=None, rtol=0.01)\n",
-    "runner = adaptive.Runner(learner, goal=2.0)\n",
+    "runner = adaptive.Runner(learner, loss_goal=2.0)\n",
     "runner.live_info()"
    ]
   },
@@ -535,7 +535,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.Learner1D(f_levels, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, goal=0.01)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -571,7 +571,7 @@
     "\n",
     "\n",
     "learner = adaptive.LearnerND(sphere, bounds=[(-1, 1), (-1, 1), (-1, 1)])\n",
-    "runner = adaptive.Runner(learner, goal=2000)\n",
+    "runner = adaptive.Runner(learner, npoints_goal=2000)\n",
     "runner.live_info()"
    ]
   },
@@ -682,7 +682,7 @@
     "learner = adaptive.Learner1D(\n",
     "    f_divergent_1d, (-1, 1), loss_per_interval=uniform_sampling_1d\n",
     ")\n",
-    "runner = adaptive.BlockingRunner(learner, goal=0.01)\n",
+    "runner = adaptive.BlockingRunner(learner, loss_goal=0.01)\n",
     "learner.plot().select(y=(0, 10000))"
    ]
   },
@@ -719,7 +719,7 @@
     ")\n",
     "\n",
     "# this takes a while, so use the async Runner so we know *something* is happening\n",
-    "runner = adaptive.Runner(learner, goal=0.02)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.02)\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.2, plotter=plot_logz)"
    ]
@@ -781,7 +781,7 @@
     "loss = partial(resolution_loss, min_distance=0.01)\n",
     "\n",
     "learner = adaptive.Learner2D(f_divergent_2d, [(-1, 1), (-1, 1)], loss_per_triangle=loss)\n",
-    "runner = adaptive.BlockingRunner(learner, goal=0.02)\n",
+    "runner = adaptive.BlockingRunner(learner, loss_goal=0.02)\n",
     "plot_logz(learner)"
    ]
   },
@@ -827,7 +827,7 @@
     "]\n",
     "\n",
     "bal_learner = adaptive.BalancingLearner(learners)\n",
-    "runner = adaptive.Runner(bal_learner, goal=0.01)\n",
+    "runner = adaptive.Runner(bal_learner, loss_goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -871,7 +871,7 @@
     "    jacobi, adaptive.Learner1D, dict(bounds=(0, 1)), combos\n",
     ")\n",
     "\n",
-    "runner = adaptive.BlockingRunner(learner, goal=0.01)\n",
+    "runner = adaptive.BlockingRunner(learner, loss_goal=0.01)\n",
     "\n",
     "# The `cdims` will automatically be set when using `from_product`, so\n",
     "# `plot()` will return a HoloMap with correctly labeled sliders.\n",
@@ -936,7 +936,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runner = adaptive.Runner(learner, goal=0.05)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.05)\n",
     "runner.live_info()"
    ]
   },
@@ -1006,7 +1006,7 @@
     "    acq_func=\"gp_hedge\",\n",
     "    acq_optimizer=\"lbfgs\",\n",
     ")\n",
-    "runner = adaptive.Runner(learner, ntasks=1, goal=40)\n",
+    "runner = adaptive.Runner(learner, ntasks=1, npoints_goal=40)\n",
     "runner.live_info()"
    ]
   },
@@ -1064,7 +1064,7 @@
     "executor = ProcessPoolExecutor(max_workers=4)\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, executor=executor, goal=0.05)\n",
+    "runner = adaptive.Runner(learner, executor=executor, loss_goal=0.05)\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.1)"
    ]
@@ -1087,7 +1087,7 @@
     "client = ipyparallel.Client()  # You will need to start an `ipcluster` to make this work\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, executor=client, goal=0.01)\n",
+    "runner = adaptive.Runner(learner, executor=client, loss_goal=0.01)\n",
     "runner.live_info()\n",
     "runner.live_plot()"
    ]
@@ -1112,7 +1112,7 @@
     "client = distributed.Client()\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, executor=client, goal=0.01)\n",
+    "runner = adaptive.Runner(learner, executor=client, loss_goal=0.01)\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.1)"
    ]
@@ -1164,7 +1164,7 @@
     "control = adaptive.Learner1D(partial(peak, wait=False), bounds=(-1, 1))\n",
     "\n",
     "# Let's only run the learner\n",
-    "runner = adaptive.Runner(learner, goal=0.01)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.01)\n",
     "runner.live_info()"
    ]
   },
@@ -1240,7 +1240,7 @@
     "\n",
     "\n",
     "learner = adaptive.Learner1D(slow_f, bounds=[0, 1])\n",
-    "runner = adaptive.Runner(learner, goal=100)\n",
+    "runner = adaptive.Runner(learner, npoints_goal=100)\n",
     "\n",
     "runner.start_periodic_saving(\n",
     "    save_kwargs=dict(fname=\"data/periodic_example.p\"), interval=6\n",
@@ -1336,7 +1336,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.Learner1D(partial(peak, wait=False), bounds=(-1, 1))\n",
-    "adaptive.BlockingRunner(learner, goal=0.005)\n",
+    "adaptive.BlockingRunner(learner, loss_goal=0.005)\n",
     "# This will only get run after the runner has finished\n",
     "learner.plot()"
    ]
@@ -1370,7 +1370,7 @@
     "learner = adaptive.Learner1D(partial(peak, wait=False), bounds=(-1, 1))\n",
     "\n",
     "# blocks until completion\n",
-    "adaptive.runner.simple(learner, goal=0.002)\n",
+    "adaptive.runner.simple(learner, loss_goal=0.002)\n",
     "\n",
     "learner.plot()"
    ]
@@ -1395,7 +1395,7 @@
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
     "\n",
     "runner = adaptive.Runner(\n",
-    "    learner, executor=SequentialExecutor(), goal=0.002\n",
+    "    learner, executor=SequentialExecutor(), loss_goal=0.002\n",
     ")\n",
     "runner.live_info()\n",
     "runner.live_plot(update_interval=0.1)"
@@ -1544,7 +1544,7 @@
    "outputs": [],
    "source": [
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, goal=0.1, log=True)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.1, log=True)\n",
     "runner.live_info()"
    ]
   },
@@ -1629,7 +1629,7 @@
     "ioloop = asyncio.get_event_loop()\n",
     "\n",
     "learner = adaptive.Learner1D(peak, bounds=(-1, 1))\n",
-    "runner = adaptive.Runner(learner, goal=0.1)\n",
+    "runner = adaptive.Runner(learner, loss_goal=0.1)\n",
     "\n",
     "timer = ioloop.create_task(time(runner))\n",
     "runner.live_info()"
@@ -1668,7 +1668,7 @@
     "\n",
     "learner = adaptive.Learner1D(peak, (-1, 1))\n",
     "\n",
-    "adaptive.BlockingRunner(learner, goal=0.1)\n",
+    "adaptive.BlockingRunner(learner, loss_goal=0.1)\n",
     "```\n",
     "\n",
     "If you use `asyncio` already in your script and want to integrate `adaptive` into it, then you can use the default `Runner` as you would from a notebook. If you want to wait for the runner to finish, then you can simply\n",

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ extras_require = {
         "distributed",
         "ipyparallel>=6.2.5",  # because of https://github.com/ipython/ipyparallel/issues/404
         "scikit-optimize>=0.8.1",  # because of https://github.com/scikit-optimize/scikit-optimize/issues/931
-        "scikit-learn<=0.24.2",  # because of https://github.com/scikit-optimize/scikit-optimize/issues/1059
+        "scikit-learn",
         "wexpect" if os.name == "nt" else "pexpect",
     ],
 }


### PR DESCRIPTION
## Description

Add more loss options to Runners to easily set common loss conditions.

For example:
```python
learner = Learner1D(...)
runner = Runner(learner, npoints_goal=100)
# or
runner = Runner(learner, loss_goal=0.01)
```

```python
learner = SequenceLearner(...)
runner = Runner(learner)  # stops when out of points
```

```python
learner = IntegratorLearner(..., rtol=0.01)
runner = simple(learner)  # stops when reached tol
```

```python
learner = BalancingLearner([list of IntegratorLearners])
runner = Runner(learner)  # stops when all reached tol
```

```python
learner = Learner1D(...)
runner = Runner(learner)  # never stops
```

```python
learner = SequenceLearner(...)
runner = Runner(learner, duration_goal=timedelta(hours=5))
```

Still one is also able to use `auto_goal`:
```python
from adaptive.runner import auto_goal
learner = Learner2D(...)
runner = Runner(learner, auto_goal(loss=0.01))
runner = Runner(learner, auto_goal(npoints=100))
runner = Runner(learner, auto_goal(timedelta=timedelta(hours=1))
```

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
