### PR TITLE
Use default executor when Runner(..., executor=None)

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -182,7 +182,7 @@ class BaseRunner(metaclass=abc.ABCMeta):
         npoints_goal: int | None = None,
         end_time_goal: datetime | None = None,
         duration_goal: timedelta | int | float | None = None,
-        executor: (ExecutorTypes | None) = None,
+        executor: ExecutorTypes | None = None,
         ntasks: int = None,
         log: bool = False,
         shutdown_executor: bool = False,
@@ -934,11 +934,9 @@ def replay_log(
 # -- Internal executor-related, things
 
 
-def _ensure_executor(
-    executor: ExecutorTypes | None,
-) -> concurrent.Executor:
+def _ensure_executor(executor: ExecutorTypes | None) -> concurrent.Executor:
     if executor is None:
-        executor = concurrent.ProcessPoolExecutor()
+        executor = _default_executor()
 
     if isinstance(executor, concurrent.Executor):
         return executor


### PR DESCRIPTION
## Description

This was accidentally broken in #370.

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
