### PR TITLE
Use codecov/codecov-action instead of removed codecov package

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,8 +13,8 @@ jobs:
       with:
         python-version: 3.7
     - name: Install dependencies
-      run: pip install nox codecov
+      run: pip install nox
     - name: Test with nox
       run: nox -e coverage
-    - name: Upload test coverage
-      run: codecov -t ${{ secrets.CODECOV_TOKEN }} -f .coverage.xml
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Description

The `codecov` package has been removed from PyPI (https://about.codecov.io/blog/message-regarding-the-pypi-package/).


## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
