### PR TITLE
Bump minimal Python to ≥3.8

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -21,10 +21,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 try:
     import pandas

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -1111,7 +1111,7 @@ class LearnerND(BaseLearner):
         vertices = []  # index -> (x,y,z)
         faces_or_lines = []  # tuple of indices of the corner points
 
-        @functools.lru_cache()
+        @functools.lru_cache
         def _get_vertex_index(a, b):
             vertex_a = self.tri.vertices[a]
             vertex_b = self.tri.vertices[b]

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -15,7 +15,7 @@ import warnings
 from contextlib import suppress
 from datetime import datetime, timedelta
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 
 import loky
 
@@ -45,11 +45,6 @@ if sys.version_info >= (3, 10):
     from typing import TypeAlias
 else:
     from typing_extensions import TypeAlias
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 with_ipyparallel = find_spec("ipyparallel") is not None

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -7,7 +7,7 @@
     "environment_type": "conda",
     "install_timeout": 600,
     "show_commit_url": "https://github.com/python-adaptive/adaptive/commits/",
-    "pythons": ["3.7"],
+    "pythons": ["3.8"],
     "conda_channels": ["conda-forge"],
     "matrix": {
         "numpy": ["1.13"],

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("all_deps", [True, False])
 def pytest(session, all_deps):
     session.install(".[testing,other]" if all_deps else ".[testing]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ dynamic = ["version"]
 description = "Parallel active learning of mathematical functions"
 maintainers = [{ name = "Adaptive authors" }]
 license = { text = "BSD" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -96,11 +95,11 @@ output = ".coverage.xml"
 
 [tool.mypy]
 ignore_missing_imports = true
-python_version = "3.7"
+python_version = "3.8"
 
 [tool.ruff]
 line-length = 150
-target-version = "py37"
+target-version = "py38"
 select = ["B", "C", "E", "F", "W", "T", "B9", "I", "UP"]
 ignore = [
     "T20",     # flake8-print


### PR DESCRIPTION
According to NEP 29, we should also already drop 3.8 even: https://numpy.org/neps/nep-0029-deprecation_policy.html


## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
