### PR TITLE
Update Python version requirement to 3.9 in accordance with NEP 29

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import math
 import sys
 from collections import defaultdict
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from math import hypot
-from typing import Callable, DefaultDict, Iterable, List, Sequence, Tuple
+from typing import Callable
 
 import numpy as np
 import scipy.stats
@@ -25,8 +26,8 @@ try:
 except ModuleNotFoundError:
     with_pandas = False
 
-Point = Tuple[int, Real]
-Points = List[Point]
+Point = tuple[int, Real]
+Points = list[Point]
 
 __all__: list[str] = ["AverageLearner1D"]
 
@@ -504,7 +505,7 @@ class AverageLearner1D(Learner1D):
             )
 
         # Create a mapping of points to a list of samples
-        mapping: DefaultDict[Real, DefaultDict[Int, Real]] = defaultdict(
+        mapping: defaultdict[Real, defaultdict[Int, Real]] = defaultdict(
             lambda: defaultdict(dict)
         )
         for (seed, x), y in zip(xs, ys):

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -21,10 +21,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 try:
     import pandas

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import itertools
 import sys
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from contextlib import suppress
 from functools import partial
 from operator import itemgetter
-from typing import Any, Callable, Dict, Sequence, Tuple, Union, cast
+from typing import Any, Callable, Union, cast
 
 import numpy as np
 
@@ -39,8 +39,8 @@ def dispatch(child_functions: list[Callable], arg: Any) -> Any:
 STRATEGY_TYPE: TypeAlias = Literal["loss_improvements", "loss", "npoints", "cycle"]
 
 CDIMS_TYPE: TypeAlias = Union[
-    Sequence[Dict[str, Any]],
-    Tuple[Sequence[str], Sequence[Tuple[Any, ...]]],
+    Sequence[dict[str, Any]],
+    tuple[Sequence[str], Sequence[tuple[Any, ...]]],
     None,
 ]
 

--- a/adaptive/learner/base_learner.py
+++ b/adaptive/learner/base_learner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Callable, Dict, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 import cloudpickle
 
@@ -66,7 +66,7 @@ def uses_nth_neighbors(n: int):
     return _wrapped
 
 
-DataType = Dict[Any, Any]
+DataType = dict[Any, Any]
 
 
 class BaseLearner(abc.ABC):

--- a/adaptive/learner/integrator_coeffs.py
+++ b/adaptive/learner/integrator_coeffs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from fractions import Fraction
-from functools import lru_cache
+from functools import cache
 
 import numpy as np
 import scipy.linalg
@@ -143,7 +143,7 @@ def calc_V(x: np.ndarray, n: int) -> np.ndarray:
     return np.array(V).T
 
 
-@lru_cache(maxsize=None)
+@cache
 def _coefficients():
     """Compute the coefficients on demand, in order to avoid doing linear algebra on import."""
     eps = np.spacing(1)

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -4,8 +4,9 @@ import collections.abc
 import itertools
 import math
 import sys
+from collections.abc import Sequence
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import cloudpickle
 import numpy as np
@@ -41,27 +42,27 @@ if TYPE_CHECKING:
     # -- types --
 
     # Commonly used types
-    Interval: TypeAlias = Union[Tuple[float, float], Tuple[float, float, int]]
-    NeighborsType: TypeAlias = SortedDict[float, List[Optional[float]]]
+    Interval: TypeAlias = Union[tuple[float, float], tuple[float, float, int]]
+    NeighborsType: TypeAlias = SortedDict[float, list[Optional[float]]]
 
     # Types for loss_per_interval functions
-    XsType0: TypeAlias = Tuple[float, float]
-    YsType0: TypeAlias = Union[Tuple[float, float], Tuple[np.ndarray, np.ndarray]]
-    XsType1: TypeAlias = Tuple[
+    XsType0: TypeAlias = tuple[float, float]
+    YsType0: TypeAlias = Union[tuple[float, float], tuple[np.ndarray, np.ndarray]]
+    XsType1: TypeAlias = tuple[
         Optional[float], Optional[float], Optional[float], Optional[float]
     ]
     YsType1: TypeAlias = Union[
-        Tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
-        Tuple[
+        tuple[Optional[float], Optional[float], Optional[float], Optional[float]],
+        tuple[
             Optional[np.ndarray],
             Optional[np.ndarray],
             Optional[np.ndarray],
             Optional[np.ndarray],
         ],
     ]
-    XsTypeN: TypeAlias = Tuple[Optional[float], ...]
+    XsTypeN: TypeAlias = tuple[Optional[float], ...]
     YsTypeN: TypeAlias = Union[
-        Tuple[Optional[float], ...], Tuple[Optional[np.ndarray], ...]
+        tuple[Optional[float], ...], tuple[Optional[np.ndarray], ...]
     ]
 
 

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import itertools
 import warnings
 from collections import OrderedDict
+from collections.abc import Iterable
 from copy import copy
 from math import sqrt
-from typing import Callable, Iterable
+from typing import Callable
 
 import cloudpickle
 import numpy as np

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -1111,7 +1111,7 @@ class LearnerND(BaseLearner):
         vertices = []  # index -> (x,y,z)
         faces_or_lines = []  # tuple of indices of the corner points
 
-        @functools.lru_cache()
+        @functools.lru_cache
         def _get_vertex_index(a, b):
             vertex_a = self.tri.vertices[a]
             vertex_b = self.tri.vertices[b]

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from copy import copy
-from typing import Any, Tuple
+from typing import Any
 
 import cloudpickle
 from sortedcontainers import SortedDict, SortedSet
@@ -28,7 +28,7 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
-PointType: TypeAlias = Tuple[Int, Any]
+PointType: TypeAlias = tuple[Int, Any]
 
 
 class _IgnoreFirstArgument:

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -15,7 +15,7 @@ import warnings
 from contextlib import suppress
 from datetime import datetime, timedelta
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 
 import loky
 
@@ -45,11 +45,6 @@ if sys.version_info >= (3, 10):
     from typing import TypeAlias
 else:
     from typing_extensions import TypeAlias
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 with_ipyparallel = find_spec("ipyparallel") is not None

--- a/adaptive/utils.py
+++ b/adaptive/utils.py
@@ -7,9 +7,10 @@ import inspect
 import os
 import pickle
 import warnings
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from itertools import product
-from typing import Any, Callable, Iterator, Sequence
+from typing import Any, Callable
 
 import cloudpickle
 
@@ -147,7 +148,7 @@ class SequentialExecutor(concurrent.Executor):
     This executor is mainly for testing.
     """
 
-    def submit(self, fn: Callable, *args, **kwargs) -> concurrent.Future:
+    def submit(self, fn: Callable, *args, **kwargs) -> concurrent.Future:  # type: ignore[override]
         fut: concurrent.Future = concurrent.Future()
         try:
             fut.set_result(fn(*args, **kwargs))

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -7,7 +7,7 @@
     "environment_type": "conda",
     "install_timeout": 600,
     "show_commit_url": "https://github.com/python-adaptive/adaptive/commits/",
-    "pythons": ["3.7"],
+    "pythons": ["3.8"],
     "conda_channels": ["conda-forge"],
     "matrix": {
         "numpy": ["1.13"],

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -7,7 +7,7 @@
     "environment_type": "conda",
     "install_timeout": 600,
     "show_commit_url": "https://github.com/python-adaptive/adaptive/commits/",
-    "pythons": ["3.8"],
+    "pythons": ["3.11"],
     "conda_channels": ["conda-forge"],
     "matrix": {
         "numpy": ["1.13"],

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
 @nox.parametrize("all_deps", [True, False])
 def pytest(session, all_deps):
     session.install(".[testing,other]" if all_deps else ".[testing]")

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=["3.8", "3.9", "3.10", "3.11"])
+@nox.session(python=["3.9", "3.10", "3.11"])
 @nox.parametrize("all_deps", [True, False])
 def pytest(session, all_deps):
     session.install(".[testing,other]" if all_deps else ".[testing]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ dynamic = ["version"]
 description = "Parallel active learning of mathematical functions"
 maintainers = [{ name = "Adaptive authors" }]
 license = { text = "BSD" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -29,8 +28,6 @@ dependencies = [
 
 [project.optional-dependencies]
 other = [
-    "ipython; python_version > '3.8'",
-    "ipython<8.13; python_version <= '3.8'", # because https://github.com/ipython/ipython/issues/14053
     "dill",
     "distributed",
     "ipyparallel>=6.2.5",                    # because of https://github.com/ipython/ipyparallel/issues/404
@@ -40,8 +37,7 @@ other = [
     "pexpect; os_name != 'nt'",
 ]
 notebook = [
-    "ipython; python_version > '3.8'",
-    "ipython<8.13; python_version <= '3.8'", # because https://github.com/ipython/ipython/issues/14053
+    "ipython",
     "ipykernel>=4.8.0",                      # because https://github.com/ipython/ipykernel/issues/274 and https://github.com/ipython/ipykernel/issues/263
     "jupyter_client>=5.2.2",                 # because https://github.com/jupyter/jupyter_client/pull/314
     "holoviews>=1.9.1",
@@ -95,11 +91,11 @@ output = ".coverage.xml"
 
 [tool.mypy]
 ignore_missing_imports = true
-python_version = "3.8"
+python_version = "3.9"
 
 [tool.ruff]
 line-length = 150
-target-version = "py38"
+target-version = "py39"
 select = ["B", "C", "E", "F", "W", "T", "B9", "I", "UP"]
 ignore = [
     "T20",     # flake8-print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ dynamic = ["version"]
 description = "Parallel active learning of mathematical functions"
 maintainers = [{ name = "Adaptive authors" }]
 license = { text = "BSD" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: BSD License",
     "Intended Audience :: Science/Research",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -96,11 +95,11 @@ output = ".coverage.xml"
 
 [tool.mypy]
 ignore_missing_imports = true
-python_version = "3.7"
+python_version = "3.8"
 
 [tool.ruff]
 line-length = 150
-target-version = "py37"
+target-version = "py38"
 select = ["B", "C", "E", "F", "W", "T", "B9", "I", "UP"]
 ignore = [
     "T20",     # flake8-print


### PR DESCRIPTION
 This PR updates the minimum required Python version to 3.9, following the recommendations of [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html). NEP 29 provides a formalized deprecation policy for supported Python versions in the scientific Python ecosystem, which can help us maintain compatibility and reduce maintenance overhead.

The proposed changes include:

- [x]   Updating the minimum Python version requirement in `pyproject.toml`
- [x]   Updating the CI/CD pipelines to test against Python 3.9
- [ ]   Updating the documentation to reflect the new requirement

Before proceeding with these changes, we'd like to gather input from the community (@jbweston and @akhmerov):

1.  Is there any reason to delay this update or maintain support for older Python versions?
2.  Are there any potential conflicts or compatibility issues that could arise from updating the minimum Python version?

Please provide your feedback and let us know if you have any concerns or suggestions related to this update.

Otherwise, I have also opened https://github.com/python-adaptive/adaptive/pull/417

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
