### PR TITLE
Ensure periodic saving fires immediately after runner task is finished

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -839,7 +839,8 @@ class AsyncRunner(BaseRunner):
         async def _saver():
             while self.status() == "running":
                 method(self.learner)
-                await asyncio.sleep(interval)
+                # No asyncio.shield needed, as 'wait' does not cancel any tasks.
+                await asyncio.wait([self.task], timeout=interval)
             method(self.learner)  # one last time
 
         self.saving_task = self.ioloop.create_task(_saver())

--- a/docs/source/tutorial/tutorial.IntegratorLearner.md
+++ b/docs/source/tutorial/tutorial.IntegratorLearner.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.14.7
 kernelspec:
   display_name: python3
   name: python3
@@ -86,9 +86,7 @@ if not runner.task.done():
 
 ```{code-cell} ipython3
 print(
-    "The integral value is {} with the corresponding error of {}".format(
-        learner.igral, learner.err
-    )
+    f"The integral value is {learner.igral} with the corresponding error of {learner.err}"
 )
 learner.plot()
 ```


### PR DESCRIPTION
## Description

This PR modifies the behavior of periodic saving to fire immediately after the runner completes.
Previously the periodic saving would wait 'interval' seconds before firing the final save event.

Fixes #439 .

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
