### PR TITLE
Add `live_info_terminal`, closes #436

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -768,14 +768,16 @@ class AsyncRunner(BaseRunner):
         """
         return live_info(self, update_interval=update_interval)
 
-    def live_info_terminal(self, *, update_interval: float = 0.5) -> asyncio.Task:
+    def live_info_terminal(
+        self, *, update_interval: float = 0.5, update_same_line: bool = True
+    ) -> asyncio.Task:
         async def _update(runner: AsyncRunner) -> None:
             try:
                 while not runner.task.done():
                     # Clear the terminal
-                    # print("\033[H\033[J", end="")
-                    print("\033[H", end="")
-                    print(_info_text(runner, separator="\t\t"))
+                    if update_same_line:
+                        print("\033[H\033[J", end="")
+                    print(_info_text(runner, separator="\t"))
                     await asyncio.sleep(update_interval)
 
             except asyncio.CancelledError:
@@ -879,6 +881,7 @@ def _info_text(runner, separator: str = "\n"):
         overhead_color = "\033[31m"  # Red
 
     info = [
+        ("time", str(datetime.now())),
         ("status", f"{color_map[status]}{status}\033[0m"),
         ("elapsed time", str(timedelta(seconds=runner.elapsed_time()))),
         ("overhead", f"{overhead_color}{overhead:.2f}%\033[0m"),
@@ -895,7 +898,7 @@ def _info_text(runner, separator: str = "\n"):
 
     width = 30
     formatted_info = [f"{k}: {v}".ljust(width) for i, (k, v) in enumerate(info)]
-    return "\t".join(formatted_info)
+    return separator.join(formatted_info)
 
 
 # Default runner

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -771,6 +771,38 @@ class AsyncRunner(BaseRunner):
     def live_info_terminal(
         self, *, update_interval: float = 0.5, overwrite_previous: bool = True
     ) -> asyncio.Task:
+        """
+        Display live information about the runner in the terminal.
+
+        This function provides a live update of the runner's status in the terminal.
+        The update can either overwrite the previous status or be printed on a new line.
+
+        Parameters
+        ----------
+        update_interval : float, optional
+            The time interval (in seconds) at which the runner's status is updated in the terminal.
+            Default is 0.5 seconds.
+        overwrite_previous : bool, optional
+            If True, each update will overwrite the previous status in the terminal.
+            If False, each update will be printed on a new line.
+            Default is True.
+
+        Returns
+        -------
+        asyncio.Task
+            The asynchronous task responsible for updating the runner's status in the terminal.
+
+        Examples
+        --------
+        >>> runner = AsyncRunner(...)
+        >>> runner.live_info_terminal(update_interval=1.0, overwrite_previous=False)
+
+        Notes
+        -----
+        This function uses ANSI escape sequences to control the terminal's cursor position.
+        It might not work as expected on all terminal emulators.
+        """
+
         async def _update(runner: AsyncRunner) -> None:
             try:
                 while not runner.task.done():

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -769,13 +769,13 @@ class AsyncRunner(BaseRunner):
         return live_info(self, update_interval=update_interval)
 
     def live_info_terminal(
-        self, *, update_interval: float = 0.5, update_same_line: bool = True
+        self, *, update_interval: float = 0.5, overwrite_previous: bool = True
     ) -> asyncio.Task:
         async def _update(runner: AsyncRunner) -> None:
             try:
                 while not runner.task.done():
-                    # Clear the terminal
-                    if update_same_line:
+                    if overwrite_previous:
+                        # Clear the terminal
                         print("\033[H\033[J", end="")
                     print(_info_text(runner, separator="\t"))
                     await asyncio.sleep(update_interval)


### PR DESCRIPTION
## Description

![Screen Recording 2023-08-20 at 1 19 30 PM](https://github.com/python-adaptive/adaptive/assets/6897215/c1cf3e39-af86-4bc0-97d2-6a6be82001d0)


Use like:

`python live-info-example.py`

```python
import adaptive
import asyncio
import random

offset = random.uniform(-0.5, 0.5)


def peak(x, offset=offset, wait=True):
    from random import random
    from time import sleep

    a = 0.01
    if wait:
        # we pretend that this is a slow function
        sleep(random())

    return x + a**2 / (a**2 + (x - offset) ** 2)

learner = adaptive.Learner1D(peak, bounds=(-1, 1))
runner = adaptive.Runner(learner, loss_goal=0.01)


async def run(runner, fname: str):
    runner.live_info_terminal(overwrite_previous=True)
    await runner.task
    runner.learner.save(fname)


runner.ioloop.run_until_complete(run(runner, "learner.pkl"))
```

Fixes #436

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
