### PR TITLE
Use ruff-format instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,12 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: check-ast
-  - repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-      - id: black-jupyter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: "v0.2.1"
     hooks:
       - id: ruff
         args: ["--fix"]
+      - id: ruff-format
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.7.1
     hooks:

--- a/adaptive/learner/average_learner1D.py
+++ b/adaptive/learner/average_learner1D.py
@@ -79,9 +79,8 @@ class AverageLearner1D(Learner1D):
         self,
         function: Callable[[tuple[int, Real]], Real],
         bounds: tuple[Real, Real],
-        loss_per_interval: None | (
-            Callable[[Sequence[Real], Sequence[Real]], float]
-        ) = None,
+        loss_per_interval: None
+        | (Callable[[Sequence[Real], Sequence[Real]], float]) = None,
         delta: float = 0.2,
         alpha: float = 0.005,
         neighbor_sampling: float = 0.3,

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -788,8 +788,8 @@ class AsyncRunner(BaseRunner):
         Parameters
         ----------
         update_interval : float, optional
-            The time interval (in seconds) at which the runner's status is updated in the terminal.
-            Default is 0.5 seconds.
+            The time interval (in seconds) at which the runner's status is updated
+            in the terminal. Default is 0.5 seconds.
         overwrite_previous : bool, optional
             If True, each update will overwrite the previous status in the terminal.
             If False, each update will be printed on a new line.
@@ -798,7 +798,8 @@ class AsyncRunner(BaseRunner):
         Returns
         -------
         asyncio.Task
-            The asynchronous task responsible for updating the runner's status in the terminal.
+            The asynchronous task responsible for updating the runner's status in
+            the terminal.
 
         Examples
         --------
@@ -807,8 +808,8 @@ class AsyncRunner(BaseRunner):
 
         Notes
         -----
-        This function uses ANSI escape sequences to control the terminal's cursor position.
-        It might not work as expected on all terminal emulators.
+        This function uses ANSI escape sequences to control the terminal's cursor
+        position. It might not work as expected on all terminal emulators.
         """
 
         async def _update(runner: AsyncRunner) -> None:
@@ -1189,7 +1190,8 @@ def auto_goal(
             for lrn in learner.learners
         ]
         return lambda learner: all(
-            goal(lrn) for lrn, goal in zip(learner.learners, goals)  # type: ignore[attr-defined]
+            goal(lrn)
+            for lrn, goal in zip(learner.learners, goals)  # type: ignore[attr-defined]
         )
     if npoints is not None:
         return lambda learner: learner.npoints >= npoints  # type: ignore[operator]

--- a/adaptive/tests/algorithm_4.py
+++ b/adaptive/tests/algorithm_4.py
@@ -319,7 +319,11 @@ class _Interval:
 
 
 def algorithm_4(
-    f: Callable, a: int, b: int, tol: float, N_loops: int = int(1e9)  # noqa: B008
+    f: Callable,
+    a: int,
+    b: int,
+    tol: float,
+    N_loops: int = int(1e9),  # noqa: B008
 ) -> tuple[float, float, int, list[_Interval]]:
     """ALGORITHM_4 evaluates an integral using adaptive quadrature. The
     algorithm uses Clenshaw-Curtis quadrature rules of increasing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ ignore_missing_imports = true
 python_version = "3.9"
 
 [tool.ruff]
-line-length = 150
+line-length = 88
 target-version = "py39"
 
 [tool.ruff.lint]
@@ -109,12 +109,13 @@ ignore = [
     "D402",    # First line should not be the function's signature
     "PLW0603", # Using the global statement to update `X` is discouraged
     "D401",    # First line of docstring should be in imperative mood
+    "E501",    # Line too long
 ]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 18
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["SLF001"]
 "ci/*" = ["INP001"]
 "tests/test_examples.py" = ["E501"]


### PR DESCRIPTION
## Description

Use Ruff instead of black, to converge to a single tool.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] (Code) style fix or documentation update
- [ ] This change requires a documentation update
