### PR TITLE
Remove async activation magic in notebook_integration.py

### DIFF
--- a/adaptive/notebook_integration.py
+++ b/adaptive/notebook_integration.py
@@ -7,7 +7,6 @@ import random
 import warnings
 from contextlib import suppress
 
-_async_enabled = False
 _holoviews_enabled = False
 _ipywidgets_enabled = False
 _plotly_enabled = False
@@ -21,7 +20,7 @@ def notebook_extension(*, _inline_js=True):
             "from a Jupyter notebook."
         )
 
-    global _async_enabled, _holoviews_enabled, _ipywidgets_enabled
+    global _holoviews_enabled, _ipywidgets_enabled
 
     # Load holoviews
     try:
@@ -50,11 +49,6 @@ def notebook_extension(*, _inline_js=True):
             RuntimeWarning,
             stacklevel=2,
         )
-
-    # Enable asyncio integration
-    if not _async_enabled:
-        get_ipython().magic("gui asyncio")  # noqa: F821
-        _async_enabled = True
 
 
 def ensure_holoviews():


### PR DESCRIPTION
This has been the default for years and seems to no longer work
## Description

Please include a summary of the change and which (if so) issue is fixed.

Fixes #(ISSUE_NUMBER_HERE)

## Checklist

- [ ] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [ ] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
