### PR TITLE
Prevent SciPy deprecation warning for `estimate_gradients_2d_global`

### DIFF
--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -12,6 +12,7 @@ import cloudpickle
 import numpy as np
 from scipy import interpolate
 from scipy.interpolate import LinearNDInterpolator
+import scipy.interpolate._interpnd as interpnd
 
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.learner.triangulation import simplex_volume_in_embedding
@@ -49,7 +50,7 @@ def deviations(ip: LinearNDInterpolator) -> list[np.ndarray]:
         The deviation per triangle.
     """
     values = ip.values / (np.ptp(ip.values, axis=0).max() or 1)
-    gradients = interpolate.interpnd.estimate_gradients_2d_global(
+    gradients = interpnd.estimate_gradients_2d_global(
         ip.tri, values, tol=1e-6
     )
 

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -11,8 +11,7 @@ from typing import Callable
 import cloudpickle
 import numpy as np
 from scipy import interpolate
-from scipy.interpolate import LinearNDInterpolator
-import scipy.interpolate._interpnd as interpnd
+from scipy.interpolate import CloughTocher2DInterpolator, LinearNDInterpolator
 
 from adaptive.learner.base_learner import BaseLearner
 from adaptive.learner.triangulation import simplex_volume_in_embedding
@@ -50,9 +49,7 @@ def deviations(ip: LinearNDInterpolator) -> list[np.ndarray]:
         The deviation per triangle.
     """
     values = ip.values / (np.ptp(ip.values, axis=0).max() or 1)
-    gradients = interpnd.estimate_gradients_2d_global(
-        ip.tri, values, tol=1e-6
-    )
+    gradients = CloughTocher2DInterpolator(ip.tri, values, tol=1e-6).grad
 
     simplices = ip.tri.simplices
     p = ip.tri.points[simplices]


### PR DESCRIPTION
Currently, I see:
```
  ~/Work/pipefunc/.venv/lib/python3.13/site-packages/adaptive/learner/learner2D.py:52: DeprecationWarning: `scipy.interpolate.interpnd.estimate_gradients_2d_global` is deprecated along with the `scipy.interpolate.interpnd` namespace. `scipy.interpolate.interpnd.estimate_gradients_2d_global` will be removed in SciPy 1.16.0, and the `scipy.interpolate.interpnd` namespace will be removed in SciPy 2.0.0.
    gradients = interpolate.interpnd.estimate_gradients_2d_global(
```

Unfortunately, `estimate_gradients_2d_global` is not exposed anywhere in SciPy. Its only use is via `CloughTocher2DInterpolator.grad`, so we use that.