### PR TITLE
Enable runtime type checking in tests with typeguard

### DIFF
--- a/.github/workflows/typeguard.yml
+++ b/.github/workflows/typeguard.yml
@@ -1,8 +1,9 @@
 name: typeguard
 
-# TODO: enable this once typeguard=4 is released and issues are fixed.
-# on:
-#   - push
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   typeguard:

--- a/adaptive/_types.py
+++ b/adaptive/_types.py
@@ -1,5 +1,6 @@
 # Only used for static type checkers, should only be imported in `if TYPE_CHECKING` block
 # Workaround described in https://github.com/agronholm/typeguard/issues/456
+
 import concurrent.futures as concurrent
 from typing import TypeAlias
 

--- a/adaptive/_types.py
+++ b/adaptive/_types.py
@@ -1,0 +1,23 @@
+# Only used for static type checkers, should only be imported in `if TYPE_CHECKING` block
+# Workaround described in https://github.com/agronholm/typeguard/issues/456
+import concurrent.futures as concurrent
+from typing import TypeAlias
+
+import distributed
+import ipyparallel
+import loky
+import mpi4py.futures
+
+from adaptive.utils import SequentialExecutor
+
+ExecutorTypes: TypeAlias = (
+    concurrent.ProcessPoolExecutor
+    | concurrent.ThreadPoolExecutor
+    | SequentialExecutor
+    | loky.reusable_executor._ReusablePoolExecutor
+    | distributed.Client
+    | distributed.cfexecutor.ClientExecutor
+    | mpi4py.futures.MPIPoolExecutor
+    | ipyparallel.Client
+    | ipyparallel.client.view.ViewExecutor
+)

--- a/adaptive/learner/balancing_learner.py
+++ b/adaptive/learner/balancing_learner.py
@@ -269,17 +269,17 @@ class BalancingLearner(BaseLearner):
             return self._ask_and_tell(n)
 
     def tell(self, x: tuple[Int, Any], y: Any) -> None:
-        index, x = x
+        index, x_ = x
         self._ask_cache.pop(index, None)
         self._loss.pop(index, None)
         self._pending_loss.pop(index, None)
-        self.learners[index].tell(x, y)
+        self.learners[index].tell(x_, y)
 
     def tell_pending(self, x: tuple[Int, Any]) -> None:
-        index, x = x
+        index, x_ = x
         self._ask_cache.pop(index, None)
         self._loss.pop(index, None)
-        self.learners[index].tell_pending(x)
+        self.learners[index].tell_pending(x_)
 
     def _losses(self, real: bool = True) -> list[float]:
         losses = []

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -5,7 +5,7 @@ import itertools
 import math
 from collections.abc import Callable, Sequence
 from copy import copy, deepcopy
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import Any, TypeAlias
 
 import cloudpickle
 import numpy as np
@@ -31,25 +31,21 @@ try:
 except ModuleNotFoundError:
     with_pandas = False
 
-if TYPE_CHECKING:
-    # -- types --
 
-    # Commonly used types
-    Interval: TypeAlias = tuple[float, float] | tuple[float, float, int]
-    NeighborsType: TypeAlias = SortedDict[float, list[float | None]]
+# Commonly used types
+Interval: TypeAlias = tuple[float, float] | tuple[float, float, int]
+NeighborsType: TypeAlias = SortedDict[float, list[float | None]]
 
-    # Types for loss_per_interval functions
-    XsType0: TypeAlias = tuple[float, float]
-    YsType0: TypeAlias = tuple[float, float] | tuple[np.ndarray, np.ndarray]
-    XsType1: TypeAlias = tuple[float | None, float | None, float | None, float | None]
-    YsType1: TypeAlias = (
-        tuple[float | None, float | None, float | None, float | None]
-        | tuple[
-            np.ndarray | None, np.ndarray | None, np.ndarray | None, np.ndarray | None
-        ]
-    )
-    XsTypeN: TypeAlias = tuple[float | None, ...]
-    YsTypeN: TypeAlias = tuple[float | None, ...] | tuple[np.ndarray | None, ...]
+# Types for loss_per_interval functions
+XsType0: TypeAlias = tuple[float, float]
+YsType0: TypeAlias = tuple[float, float] | tuple[np.ndarray, np.ndarray]
+XsType1: TypeAlias = tuple[float | None, float | None, float | None, float | None]
+YsType1: TypeAlias = (
+    tuple[float | None, float | None, float | None, float | None]
+    | tuple[np.ndarray | None, np.ndarray | None, np.ndarray | None, np.ndarray | None]
+)
+XsTypeN: TypeAlias = tuple[float | None, ...]
+YsTypeN: TypeAlias = tuple[float | None, ...] | tuple[np.ndarray | None, ...]
 
 
 __all__ = [

--- a/adaptive/learner/learner1D.py
+++ b/adaptive/learner/learner1D.py
@@ -106,18 +106,18 @@ def abs_min_log_loss(xs: XsType0, ys: YsType0) -> Float:
 @uses_nth_neighbors(1)
 def triangle_loss(xs: XsType1, ys: YsType1) -> Float:
     assert len(xs) == 4
-    xs = [x for x in xs if x is not None]  # type: ignore[assignment]
-    ys = [y for y in ys if y is not None]  # type: ignore[assignment]
+    x = [x for x in xs if x is not None]
+    y = [y for y in ys if y is not None]
 
-    if len(xs) == 2:  # we do not have enough points for a triangle
-        return xs[1] - xs[0]  # type: ignore[operator]
+    if len(x) == 2:  # we do not have enough points for a triangle
+        return x[1] - x[0]  # type: ignore[operator]
 
-    N = len(xs) - 2  # number of constructed triangles
-    if isinstance(ys[0], collections.abc.Iterable):
-        pts = [(x, *y) for x, y in zip(xs, ys)]  # type: ignore[misc]
+    N = len(x) - 2  # number of constructed triangles
+    if isinstance(y[0], collections.abc.Iterable):
+        pts = [(x, *y) for x, y in zip(x, y)]  # type: ignore[misc]
         vol = simplex_volume_in_embedding
     else:
-        pts = list(zip(xs, ys))
+        pts = list(zip(x, y))
         vol = volume
     return sum(vol(pts[i : i + 3]) for i in range(N)) / N
 

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -140,7 +140,7 @@ class SequenceLearner(BaseLearner):
         self._to_do_indices.discard(index)
 
     def tell_pending(self, point: PointType) -> None:
-        index, point = point
+        index, _ = point
         self.pending_points.add(index)
         self._to_do_indices.discard(index)
 

--- a/adaptive/learner/sequence_learner.py
+++ b/adaptive/learner/sequence_learner.py
@@ -134,7 +134,7 @@ class SequenceLearner(BaseLearner):
         self.pending_points = set()
 
     def tell(self, point: PointType, value: Any) -> None:
-        index, point = point
+        index, _ = point
         self.data[index] = value
         self.pending_points.discard(index)
         self._to_do_indices.discard(index)

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -24,31 +24,17 @@ from adaptive.learner.base_learner import LearnerType
 from adaptive.notebook_integration import in_ipynb, live_info, live_plot
 from adaptive.utils import SequentialExecutor
 
+FutureTypes: TypeAlias = concurrent.Future | asyncio.Future
+
 if TYPE_CHECKING:
     import holoviews
+
+    from ._types import ExecutorTypes
 
 
 with_ipyparallel = find_spec("ipyparallel") is not None
 with_distributed = find_spec("distributed") is not None
 with_mpi4py = find_spec("mpi4py") is not None
-
-if TYPE_CHECKING:
-    import distributed
-    import ipyparallel
-    import mpi4py.futures
-
-    ExecutorTypes: TypeAlias = (
-        concurrent.ProcessPoolExecutor
-        | concurrent.ThreadPoolExecutor
-        | SequentialExecutor
-        | loky.reusable_executor._ReusablePoolExecutor
-        | distributed.Client
-        | distributed.cfexecutor.ClientExecutor
-        | mpi4py.futures.MPIPoolExecutor
-        | ipyparallel.Client
-        | ipyparallel.client.view.ViewExecutor
-    )
-    FutureTypes: TypeAlias = concurrent.Future | asyncio.Future
 
 
 with suppress(ModuleNotFoundError):
@@ -906,7 +892,7 @@ def _info_text(runner, separator: str = "\n"):
         info.append(("# of samples", runner.learner.nsamples))
 
     with suppress(Exception):
-        info.append(("latest loss", f'{runner.learner._cache["loss"]:.3f}'))
+        info.append(("latest loss", f"{runner.learner._cache['loss']:.3f}"))
 
     width = 30
     formatted_info = [f"{k}: {v}".ljust(width) for i, (k, v) in enumerate(info)]

--- a/adaptive/tests/test_average_learner.py
+++ b/adaptive/tests/test_average_learner.py
@@ -1,14 +1,10 @@
 import random
-from typing import TYPE_CHECKING
 
 import flaky
 import numpy as np
 
 from adaptive.learner import AverageLearner
 from adaptive.runner import simple
-
-if TYPE_CHECKING:
-    pass
 
 
 def f_unused(seed):

--- a/adaptive/tests/test_average_learner1d.py
+++ b/adaptive/tests/test_average_learner1d.py
@@ -1,5 +1,4 @@
 from itertools import chain
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -9,9 +8,6 @@ from adaptive.tests.test_learners import (
     noisy_peak,
     simple_run,
 )
-
-if TYPE_CHECKING:
-    pass
 
 
 def almost_equal_dicts(a, b):

--- a/adaptive/tests/test_balancing_learner.py
+++ b/adaptive/tests/test_balancing_learner.py
@@ -35,7 +35,7 @@ def test_distribute_first_points_over_learners(strategy):
         learner = BalancingLearner(learners, strategy=strategy)
 
         points = learner.ask(initial_points)[0]
-        learner.tell_many(points, points)
+        learner.tell_many(points, [x for i, x in points])
 
         points, _ = learner.ask(100)
         i_learner, xs = zip(*points)

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import random
 import time
-from typing import TYPE_CHECKING
 
 import flaky
 import numpy as np
@@ -10,9 +9,6 @@ import numpy as np
 from adaptive.learner import Learner1D
 from adaptive.learner.learner1D import curvature_loss_function
 from adaptive.runner import BlockingRunner, simple
-
-if TYPE_CHECKING:
-    pass
 
 
 def flat_middle(x):

--- a/adaptive/tests/test_notebook_integration.py
+++ b/adaptive/tests/test_notebook_integration.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 
-if TYPE_CHECKING:
-    pass
 try:
     import ipykernel.iostream
     import zmq


### PR DESCRIPTION
Re-enables the typeguard job that I disabled 2 years ago in https://github.com/python-adaptive/adaptive/pull/415.