### PR TITLE
Fix 2 NumPy deprecation warnings

### DIFF
--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -287,6 +287,10 @@ def thresholded_loss_function(
     return custom_loss
 
 
+def _cross_2d(x, y):
+    return x[..., 0] * y[..., 1] - x[..., 1] * y[..., 0]
+
+
 def choose_point_in_triangle(triangle: np.ndarray, max_badness: int) -> np.ndarray:
     """Choose a new point in inside a triangle.
 
@@ -310,7 +314,7 @@ def choose_point_in_triangle(triangle: np.ndarray, max_badness: int) -> np.ndarr
         The x and y coordinate of the suggested new point.
     """
     a, b, c = triangle
-    area = 0.5 * np.cross(b - a, c - a)
+    area = 0.5 * _cross_2d(b - a, c - a)
     triangle_roll = np.roll(triangle, 1, axis=0)
     edge_lengths = np.linalg.norm(triangle - triangle_roll, axis=1)
     i = edge_lengths.argmax()

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -726,9 +726,10 @@ class LearnerND(BaseLearner):
 
         if self.nth_neighbors == 0:
             # compute the loss on the scaled simplex
-            return float(
-                self.loss_per_simplex(vertices, values, self._output_multiplier)
-            )
+            loss = self.loss_per_simplex(vertices, values, self._output_multiplier)
+            if isinstance(loss, np.ndarray):
+                return float(loss.item())
+            return float(loss)
 
         # We do need the neighbors
         neighbors = self.tri.get_opposing_vertices(simplex)


### PR DESCRIPTION
Fixes:

```
FAILED adaptive/tests/test_learners.py::test_learner_performance_is_invariant_under_scaling[LearnerND-ring_of_fire-learner_kwargs12] - DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
```

and

```
.venv/lib/python3.13/site-packages/adaptive/learner/learner2D.py:313: in choose_point_in_triangle
    area = 0.5 * np.cross(b - a, c - a)
        if a.shape[-1] == 2 or b.shape[-1] == 2:
            # Deprecated in NumPy 2.0, 2023-09-26
>           warnings.warn(
                "Arrays of 2-dimensional vectors are deprecated. Use arrays of "
                "3-dimensional vectors instead. (deprecated in NumPy 2.0)",
                DeprecationWarning, stacklevel=2
            )
E           DeprecationWarning: Arrays of 2-dimensional vectors are deprecated. Use arrays of 3-dimensional vectors instead. (deprecated in NumPy 2.0)
```
