### PR TITLE
Remove for loops in deviations function body

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ With minimal code, you can perform evaluations on a computing cluster, display l
 
 Adaptive is most efficient for computations where each function evaluation takes at least ≈50ms due to the overhead of selecting potentially interesting points.
 
-To see Adaptive in action, try the [example notebook on Binder](https://mybinder.org/v2/gh/python-adaptive/adaptive/main?filepath=example-notebook.ipynb) or explore the [tutorial on Read the Docs](https://adaptive.readthedocs.io/en/latest/tutorial/tutorial.html).
+To see Adaptive in action, try the [example notebook on Binder](https://mybinder.org/v2/gh/python-adaptive/adaptive/main?filepath=example-notebook.ipynb) or explore the [tutorial on Read the Docs](https://adaptive.readthedocs.io/en/latest/tutorial/tutorial).
 
 <!-- summary-end -->
 

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -33,7 +33,7 @@ except ModuleNotFoundError:
 # Learner2D and helper functions.
 
 
-def deviations(ip: LinearNDInterpolator) -> list[np.ndarray]:
+def deviations(ip: LinearNDInterpolator) -> np.ndarray:
     """Returns the deviation of the linear estimate.
 
     Is useful when defining custom loss functions.
@@ -55,18 +55,14 @@ def deviations(ip: LinearNDInterpolator) -> list[np.ndarray]:
     vs = values[simplices]
     gs = gradients[simplices]
 
-    def deviation(p, v, g):
-        dev = 0
-        for j in range(3):
-            vest = v[:, j, None] + (
-                (p[:, :, :] - p[:, j, None, :]) * g[:, j, None, :]
-            ).sum(axis=-1)
-            dev += abs(vest - v).max(axis=1)
-        return dev
+    p = np.expand_dims(p, axis=2)
 
-    n_levels = vs.shape[2]
-    devs = [deviation(p, vs[:, :, i], gs[:, :, i]) for i in range(n_levels)]
-    return devs
+    p_diff = p[:, None] - p[:, :, None]
+    p_diff_scaled = p_diff * gs[:, :, None]
+    vest = vs[:, :, None] + p_diff_scaled.sum(axis=-1)
+    devs = np.sum(np.max(np.abs(vest - vs[:, None]), axis=2), axis=1)
+
+    return np.swapaxes(devs, 0, 1)
 
 
 def areas(ip: LinearNDInterpolator) -> np.ndarray:

--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -44,7 +44,7 @@ def deviations(ip: LinearNDInterpolator) -> np.ndarray:
 
     Returns
     -------
-    deviations : list
+    deviations : numpy.ndarray
         The deviation per triangle.
     """
     values = ip.values / (np.ptp(ip.values, axis=0).max() or 1)

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -294,7 +294,7 @@ def test_learner2d_vector_valued_function():
         return [x + y, x * y, x - y]  # Returns 3-element vector
 
     # Create learner with vector-valued function
-    learner = Learner2D(vector_function, bounds=[(-1, 1), (-1, 1)])
+    learner = Learner2D(vector_function, bounds=((-1, 1), (-1, 1)))
 
     # Add some initial points
     points = [

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -286,8 +286,6 @@ def test_learner2d_vector_valued_function():
     the function returns a vector (array/list) of values instead of a scalar.
     """
 
-    from adaptive import Learner2D
-
     def vector_function(xy):
         """A 2D function that returns a 3-element vector."""
         x, y = xy


### PR DESCRIPTION
## Description

I am trying to adapt `adaptive` for sequential operations with a relatively fast function. I really love the package and would like to experiment with speeding up the learners themselves. This is a minor change which does not affect the speed much, as interpolators seem to be bottleneck, but since I already implemented it, I figured I'd share it :)

I also noticed the tutorial link in README is broken, so I included it here as it is a tiny change, but can remove it if you'd like.

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] (Code) style fix or documentation update
- [ ] This change requires a documentation update
