### PR TITLE
Add customizable number of points in simple runner.

### DIFF
--- a/adaptive/learner/learner2D.py
+++ b/adaptive/learner/learner2D.py
@@ -817,7 +817,7 @@ class Learner2D(BaseLearner):
             if p not in self.data:
                 self._stack[p] = np.inf
 
-    def plot(self, n=None, tri_alpha=0):
+    def plot(self, n=None, tri_alpha=0.0):
         r"""Plot the Learner2D's current state.
 
         This plot function interpolates the data on a regular grid.

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -911,7 +911,7 @@ def simple(
     npoints_goal: int | None = None,
     end_time_goal: datetime | None = None,
     duration_goal: timedelta | int | float | None = None,
-    points_per_ask: int | None = 1,
+    points_per_ask: int = 1,
 ):
     """Run the learner until the goal is reached.
 

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -911,11 +911,12 @@ def simple(
     npoints_goal: int | None = None,
     end_time_goal: datetime | None = None,
     duration_goal: timedelta | int | float | None = None,
+    points_per_ask: int | None = 1,
 ):
     """Run the learner until the goal is reached.
 
-    Requests a single point from the learner, evaluates
-    the function to be learned, and adds the point to the
+    Requests points from the learner, evaluates
+    the function to be learned, and adds the points to the
     learner, until the goal is reached, blocking the current
     thread.
 
@@ -946,6 +947,9 @@ def simple(
         calculation. Stop when the current time is larger or equal than
         ``start_time + duration_goal``. ``duration_goal`` can be a number
         indicating the number of seconds.
+    points_per_ask : int, optional
+        The number of points to ask for between every interpolation rerun. Defaults
+        to 1, which can introduce significant overhead on long runs.
     """
     goal = _goal(
         learner,
@@ -958,7 +962,7 @@ def simple(
     )
     assert goal is not None
     while not goal(learner):
-        xs, _ = learner.ask(1)
+        xs, _ = learner.ask(points_per_ask)
         for x in xs:
             y = learner.function(x)
             learner.tell(x, y)


### PR DESCRIPTION
## Description

My use case has a function that is already fast due to parallel execution. As such, not only does it evaluate quicker than 50ms, but also freezes my PC when run with parallel runner. As such, I found the `simple` runner very useful, but it also introduces overhead by running the interpolants on ever new point. Increasing the `ask` count to 16 (my number of cores to mimic the parallel version), diminished that to overhead to almost nothing, but I would prefer to not have to monkey patch this function :)

## Checklist

- [x] Fixed style issues using `pre-commit run --all` (first install using `pip install pre-commit`)
- [x] `pytest` passed

## Type of change

*Check relevant option(s).*

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] (Code) style fix or documentation update
- [ ] This change requires a documentation update
