### PR TITLE
Fix AsyncRunner failure on Python 3.14 due to asyncio.get_event_loop() removal

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -626,7 +626,18 @@ class AsyncRunner(BaseRunner):
             raise_if_retries_exceeded=raise_if_retries_exceeded,
             allow_running_forever=True,
         )
-        self.ioloop = ioloop or asyncio.get_event_loop()
+        if ioloop is not None:
+            self.ioloop = ioloop
+        else:
+            try:
+                self.ioloop = asyncio.get_running_loop()
+            except RuntimeError:
+                # No running event loop exists (e.g., running outside of async context).
+                # Create a new event loop. This is needed for Python 3.10+ where
+                # asyncio.get_event_loop() is deprecated when no loop is running,
+                # and Python 3.14+ where it raises RuntimeError.
+                self.ioloop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self.ioloop)
 
         # When the learned function is 'async def', we run it
         # directly on the event loop, and not in the executor.

--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -626,18 +626,7 @@ class AsyncRunner(BaseRunner):
             raise_if_retries_exceeded=raise_if_retries_exceeded,
             allow_running_forever=True,
         )
-        if ioloop is not None:
-            self.ioloop = ioloop
-        else:
-            try:
-                self.ioloop = asyncio.get_running_loop()
-            except RuntimeError:
-                # No running event loop exists (e.g., running outside of async context).
-                # Create a new event loop. This is needed for Python 3.10+ where
-                # asyncio.get_event_loop() is deprecated when no loop is running,
-                # and Python 3.14+ where it raises RuntimeError.
-                self.ioloop = asyncio.new_event_loop()
-                asyncio.set_event_loop(self.ioloop)
+        self.ioloop = ioloop if ioloop is not None else _get_or_create_event_loop()
 
         # When the learned function is 'async def', we run it
         # directly on the event loop, and not in the executor.
@@ -998,7 +987,22 @@ def replay_log(
         getattr(learner, method)(*args)
 
 
-# -- Internal executor-related, things
+# -- Internal executor-related things
+
+
+def _get_or_create_event_loop() -> asyncio.AbstractEventLoop:
+    """Get the running event loop or create a new one.
+
+    In Python 3.10+, asyncio.get_event_loop() is deprecated when no loop is running.
+    In Python 3.14+, it raises RuntimeError instead of creating a new loop.
+    This function provides a compatible way to get or create an event loop.
+    """
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
 
 
 def _ensure_executor(executor: ExecutorTypes | None) -> concurrent.Executor:

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -1,4 +1,3 @@
-import asyncio
 import platform
 import sys
 import time
@@ -264,26 +263,3 @@ def test_simple_points_per_ask():
     finally:
         # Restore original method
         Learner1D.ask = original_ask
-
-
-def test_async_runner_without_running_event_loop():
-    """Test that AsyncRunner works when no event loop is running.
-
-    In Python 3.10+, asyncio.get_event_loop() was deprecated when no running
-    event loop exists. In Python 3.12+ it emits a DeprecationWarning, and in
-    Python 3.14+ it raises a RuntimeError.
-
-    This test ensures AsyncRunner properly handles the case when no event
-    loop is running by creating one.
-
-    Regression test for: https://github.com/python-adaptive/adaptive/issues/489
-    """
-    # Ensure no event loop is currently running
-    with pytest.raises(RuntimeError, match="no running event loop"):
-        asyncio.get_running_loop()
-
-    # AsyncRunner should still work - it should create its own event loop
-    learner = Learner1D(linear, (-1, 1))
-    runner = AsyncRunner(learner, npoints_goal=10, executor=SequentialExecutor())
-    runner.block_until_done()
-    assert learner.npoints >= 10

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -1,3 +1,4 @@
+import asyncio
 import platform
 import sys
 import time
@@ -263,3 +264,35 @@ def test_simple_points_per_ask():
     finally:
         # Restore original method
         Learner1D.ask = original_ask
+
+
+def test_async_runner_without_event_loop():
+    """Test that AsyncRunner works when no event loop exists.
+
+    In Python 3.10+, asyncio.get_event_loop() was deprecated when no running
+    event loop exists. In Python 3.12+ it emits a DeprecationWarning, and in
+    Python 3.14+ it raises a RuntimeError.
+
+    This test ensures AsyncRunner properly handles the case when no event
+    loop exists by creating one.
+
+    Regression test for: https://github.com/python-adaptive/adaptive/issues/489
+    """
+
+    def run_in_thread():
+        """Run AsyncRunner in a thread with no event loop."""
+        # Ensure no event loop exists in this thread
+        with pytest.raises(RuntimeError, match="no.*event loop"):
+            asyncio.get_running_loop()
+
+        # AsyncRunner should still work - it should create its own event loop
+        learner = Learner1D(linear, (-1, 1))
+        runner = AsyncRunner(learner, npoints_goal=10, executor=SequentialExecutor())
+        runner.block_until_done()
+        assert learner.npoints >= 10
+
+    import threading
+
+    thread = threading.Thread(target=run_in_thread)
+    thread.start()
+    thread.join()

--- a/adaptive/tests/test_runner.py
+++ b/adaptive/tests/test_runner.py
@@ -266,33 +266,24 @@ def test_simple_points_per_ask():
         Learner1D.ask = original_ask
 
 
-def test_async_runner_without_event_loop():
-    """Test that AsyncRunner works when no event loop exists.
+def test_async_runner_without_running_event_loop():
+    """Test that AsyncRunner works when no event loop is running.
 
     In Python 3.10+, asyncio.get_event_loop() was deprecated when no running
     event loop exists. In Python 3.12+ it emits a DeprecationWarning, and in
     Python 3.14+ it raises a RuntimeError.
 
     This test ensures AsyncRunner properly handles the case when no event
-    loop exists by creating one.
+    loop is running by creating one.
 
     Regression test for: https://github.com/python-adaptive/adaptive/issues/489
     """
+    # Ensure no event loop is currently running
+    with pytest.raises(RuntimeError, match="no running event loop"):
+        asyncio.get_running_loop()
 
-    def run_in_thread():
-        """Run AsyncRunner in a thread with no event loop."""
-        # Ensure no event loop exists in this thread
-        with pytest.raises(RuntimeError, match="no.*event loop"):
-            asyncio.get_running_loop()
-
-        # AsyncRunner should still work - it should create its own event loop
-        learner = Learner1D(linear, (-1, 1))
-        runner = AsyncRunner(learner, npoints_goal=10, executor=SequentialExecutor())
-        runner.block_until_done()
-        assert learner.npoints >= 10
-
-    import threading
-
-    thread = threading.Thread(target=run_in_thread)
-    thread.start()
-    thread.join()
+    # AsyncRunner should still work - it should create its own event loop
+    learner = Learner1D(linear, (-1, 1))
+    runner = AsyncRunner(learner, npoints_goal=10, executor=SequentialExecutor())
+    runner.block_until_done()
+    assert learner.npoints >= 10

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ import nox
 
 nox.options.default_venv_backend = "uv"
 
-python = ["3.11", "3.12", "3.13"]
+python = ["3.11", "3.12", "3.13", "3.14"]
 num_cpus = os.cpu_count() or 1
 xdist = ("-n", "auto") if num_cpus > 2 else ()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "scipy",


### PR DESCRIPTION
## Summary
- Fix `AsyncRunner` instantiation failure on Python 3.14 where `asyncio.get_event_loop()` raises `RuntimeError` when no event loop is running
- Add `_get_or_create_event_loop()` helper that uses `get_running_loop()` with fallback to `new_event_loop()`
- Add Python 3.14 to CI matrix

## Test plan
- [x] Existing tests pass on Python 3.14

Fixes #489