### PR TITLE
Fix flaky CI tests: make flaky reruns draw fresh random values

### DIFF
--- a/adaptive/tests/flaky_utils.py
+++ b/adaptive/tests/flaky_utils.py
@@ -1,0 +1,39 @@
+"""Make ``flaky`` reruns work with ``pytest-randomly``."""
+
+import functools as ft
+import random
+from collections import Counter
+
+import numpy as np
+
+_attempts: Counter = Counter()
+
+
+def fresh_seed_each_run(func):
+    """Make ``@flaky.flaky`` reruns draw new random values.
+
+    ``pytest-randomly`` reseeds the global RNG at the start of every test
+    call phase — including reruns triggered by the ``flaky`` plugin — so a
+    randomized test that fails for the session seed fails identically on
+    every rerun, making the retries useless. Reseeding cannot happen in a
+    fixture (``pytest-randomly`` reseeds in ``pytest_runtest_call``, after
+    fixture setup), so this mixes the attempt number into the seed at the
+    start of the test call itself. Each rerun gets new draws while the
+    whole sequence stays reproducible via ``--randomly-seed``.
+
+    Apply directly on the test function, below ``@flaky.flaky`` and any
+    parametrization.
+    """
+
+    @ft.wraps(func)
+    def wrapper(*args, **kwargs):
+        key = (func.__qualname__, repr(args), repr(kwargs))
+        attempt = _attempts[key]
+        _attempts[key] += 1
+        if attempt:
+            seed = (random.getrandbits(32) + attempt) % 2**32
+            random.seed(seed)
+            np.random.seed(seed)
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/adaptive/tests/test_average_learner.py
+++ b/adaptive/tests/test_average_learner.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from adaptive.learner import AverageLearner
 from adaptive.runner import simple
+from adaptive.tests.flaky_utils import fresh_seed_each_run
 
 
 def f_unused(seed):
@@ -28,6 +29,7 @@ def test_only_returns_new_points():
 
 
 @flaky.flaky(max_runs=5)
+@fresh_seed_each_run
 def test_avg_std_and_npoints():
     learner = AverageLearner(f_unused, atol=None, rtol=0.01)
 

--- a/adaptive/tests/test_learner1d.py
+++ b/adaptive/tests/test_learner1d.py
@@ -9,6 +9,7 @@ import numpy as np
 from adaptive.learner import Learner1D
 from adaptive.learner.learner1D import curvature_loss_function
 from adaptive.runner import BlockingRunner, simple
+from adaptive.tests.flaky_utils import fresh_seed_each_run
 
 
 def flat_middle(x):
@@ -259,6 +260,7 @@ def test_ask_does_not_return_known_points_when_returning_bounds():
 
 
 @flaky.flaky(max_runs=3)
+@fresh_seed_each_run
 def test_tell_many():
     def f(x, offset=0.123214):
         a = 0.01

--- a/adaptive/tests/test_learners.py
+++ b/adaptive/tests/test_learners.py
@@ -29,6 +29,7 @@ from adaptive.learner import (
 )
 from adaptive.learner.learner1D import with_pandas
 from adaptive.runner import simple
+from adaptive.tests.flaky_utils import fresh_seed_each_run
 
 LOSS_FUNCTIONS = {
     Learner1D: (
@@ -514,7 +515,9 @@ def test_expected_loss_improvement_is_less_than_total_loss(
 
 # XXX: This *should* pass (https://github.com/python-adaptive/adaptive/issues/55)
 #      but we xfail it now, as Learner2D will be deprecated anyway
+@flaky.flaky(max_runs=5)
 @run_with(Learner1D, xfail(Learner2D), LearnerND, AverageLearner1D)
+@fresh_seed_each_run
 def test_learner_performance_is_invariant_under_scaling(
     learner_type, f, learner_kwargs
 ):
@@ -583,6 +586,7 @@ def test_learner_performance_is_invariant_under_scaling(
     SequenceLearner,
     with_all_loss_functions=False,
 )
+@fresh_seed_each_run
 def test_balancing_learner(learner_type, f, learner_kwargs):
     """Test if the BalancingLearner works with the different types of learners."""
     learners = [


### PR DESCRIPTION
## Problem

CI fails intermittently on randomized tests, including on PRs that touch no code (the `pre-commit-ci` autoupdate PRs) and on `main` itself. Failures found in recent run history:

| Test | Failing runs |
|---|---|
| `test_balancing_learner[AverageLearner-gaussian]` | [25698219293](https://github.com/python-adaptive/adaptive/actions/runs/25698219293), [24054088102](https://github.com/python-adaptive/adaptive/actions/runs/24054088102), [23168580248](https://github.com/python-adaptive/adaptive/actions/runs/23168580248) |
| `test_balancing_learner[Learner2D-ring_of_fire]` | [24021387134](https://github.com/python-adaptive/adaptive/actions/runs/24021387134) (on `main`), [24609450338](https://github.com/python-adaptive/adaptive/actions/runs/24609450338) |
| `test_learner_performance_is_invariant_under_scaling` | [27297286567](https://github.com/python-adaptive/adaptive/actions/runs/27297286567), [23768978596](https://github.com/python-adaptive/adaptive/actions/runs/23768978596), [23768968649](https://github.com/python-adaptive/adaptive/actions/runs/23768968649) |
| `test_learner1d.py::test_tell_many` | [24010073833](https://github.com/python-adaptive/adaptive/actions/runs/24010073833) |

## Root cause

Most of these tests already have `@flaky.flaky(max_runs=N)`, but the retries never help: **`pytest-randomly` reseeds the global RNG at the start of every test call phase — including reruns triggered by `flaky` — so every retry replays the exact same failure.**

Reproduced locally with the seed from run 25698219293:

```
$ pytest "adaptive/tests/test_learners.py::test_balancing_learner[AverageLearner-gaussian-learner_kwargs5]" --randomly-seed=4082421528
...
AssertionError: [192, 2, 186, 180]   # identical values to CI, on all 10 flaky retries
```

## Fix

Add `fresh_seed_each_run`, a decorator that mixes the rerun attempt number into the RNG seed at the start of the test call. This cannot be done in a fixture: `pytest-randomly` reseeds in `pytest_runtest_call`, *after* fixture setup. The first attempt keeps `pytest-randomly`'s seed untouched, and the derived rerun seeds are a pure function of the session seed, so everything stays reproducible via `--randomly-seed`.

- Apply it to all `@flaky.flaky` tests (`test_balancing_learner`, `test_avg_std_and_npoints`, `test_tell_many`).
- Add `@flaky.flaky(max_runs=5)` to `test_learner_performance_is_invariant_under_scaling`, which had no retries at all (its float tie-breaking divergence between scaled and control learner is seed-dependent).

## Verification

With the fix, the reproduced CI failure recovers on the first retry:

```
$ pytest "...test_balancing_learner[AverageLearner-gaussian-learner_kwargs5]" --randomly-seed=4082421528
test_balancing_learner[AverageLearner-gaussian-learner_kwargs5] failed (9 runs remaining out of 10).
test_balancing_learner[AverageLearner-gaussian-learner_kwargs5] passed 1 out of the required 1 times. Success!
1 passed
```

- Full suite passes: `282 passed, 16 skipped, 64 xfailed, 25 xpassed` (Python 3.13, macOS).
- Scaling test passes on Python 3.14 with the seed from run 27297286567, with `xfail`/`xpass` params unaffected by the wrapper.
- A 40-seed sweep of the balancing test showed no failed attempts, consistent with the low base failure rate (CI only hits it because every push runs a 12-job matrix with 2 pytest sessions each).