### PR TITLE
Fix failing Read the Docs builds: raise myst-nb execution timeout

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,7 +79,9 @@ html_logo = "_static/logo_docs.png"
 
 # myst-nb configuration
 nb_execution_mode = "cache"
-nb_execution_timeout = 180
+# Generating the logo animation (logo.md) takes ~3 minutes on Read the Docs
+# builders, which intermittently exceeded the previous 180 s limit.
+nb_execution_timeout = 600
 nb_execution_raise_on_error = True
 
 


### PR DESCRIPTION
## Problem

Read the Docs builds have been failing intermittently (e.g. [build 33082181](https://app.readthedocs.org/projects/adaptive/builds/33082181/) for `latest`, plus builds for #493 and several PR previews) with:

```
nbclient.exceptions.CellTimeoutError: A cell timed out while it was being executed, after 180 seconds.
myst_nb.core.execute.base.ExecutionError: .../docs/source/logo.md
```

The `logo.md` notebook regenerates the animated docs logo on every build (the `.webm` is not committed): it runs a `Learner2D`, renders 360 PNG frames, and encodes them with libvpx-vp9. On Read the Docs builders this takes close to 3 minutes, so it lands right around the 180 s `nb_execution_timeout` — sometimes passing, sometimes not. The build history shows the same flakiness: identical doc content alternates between success and failure depending on builder speed.

## Fix

Raise `nb_execution_timeout` from 180 to 600 seconds in `docs/source/conf.py`, giving the logo cell (and any other slow notebook) comfortable headroom without affecting builds that finish quickly.

## Verification

The RTD build for this PR's preview version should be the real test — all recent failures reproduce only on RTD builders.