### PR TITLE
Do not implicitly shut down the shared reusable executor

### DIFF
--- a/adaptive/runner.py
+++ b/adaptive/runner.py
@@ -92,8 +92,9 @@ class BaseRunner(metaclass=abc.ABCMeta):
         If True, record the method calls made to the learner by this runner.
     shutdown_executor : bool, default: False
         If True, shutdown the executor when the runner has completed. If
-        `executor` is not provided then the executor created internally
-        by the runner is shut down, regardless of this parameter.
+        `executor` is not provided then the runner uses loky's reusable
+        executor, which is shared between runners and is therefore not
+        shut down unless this parameter is True.
     retries : int, default: 0
         Maximum amount of retries of a certain point ``x`` in
         ``learner.function(x)``. After `retries` is reached for ``x``
@@ -159,9 +160,11 @@ class BaseRunner(metaclass=abc.ABCMeta):
 
         self._pending_tasks: dict[FutureTypes, int] = {}
 
-        # if we instantiate our own executor, then we are also responsible
-        # for calling 'shutdown'
-        self.shutdown_executor = shutdown_executor or (executor is None)
+        # The internally created executor (when `executor is None`) is loky's
+        # reusable executor, a singleton shared between all runners, so we
+        # must not shut it down implicitly: another runner may still be using
+        # it. Pass `shutdown_executor=True` to shut it down anyway.
+        self.shutdown_executor = shutdown_executor
 
         self.learner = learner
         self.log: list | None = [] if log else None
@@ -378,8 +381,9 @@ class BlockingRunner(BaseRunner):
         If True, record the method calls made to the learner by this runner.
     shutdown_executor : bool, default: False
         If True, shutdown the executor when the runner has completed. If
-        `executor` is not provided then the executor created internally
-        by the runner is shut down, regardless of this parameter.
+        `executor` is not provided then the runner uses loky's reusable
+        executor, which is shared between runners and is therefore not
+        shut down unless this parameter is True.
     retries : int, default: 0
         Maximum amount of retries of a certain point ``x`` in
         ``learner.function(x)``. After `retries` is reached for ``x``
@@ -524,8 +528,9 @@ class AsyncRunner(BaseRunner):
         If True, record the method calls made to the learner by this runner.
     shutdown_executor : bool, default: False
         If True, shutdown the executor when the runner has completed. If
-        `executor` is not provided then the executor created internally
-        by the runner is shut down, regardless of this parameter.
+        `executor` is not provided then the runner uses loky's reusable
+        executor, which is shared between runners and is therefore not
+        shut down unless this parameter is True.
     ioloop : ``asyncio.AbstractEventLoop``, optional
         The ioloop in which to run the learning algorithm. If not provided,
         the default event loop is used.


### PR DESCRIPTION
## What

Follow-up to #497. Runners no longer shut down the internally created executor when they finish; `shutdown_executor` now defaults to plain `False` semantics (explicit opt-in), and the docstrings are updated accordingly.

## Why

Since #497, every runner with `executor=None` shares loky's reusable executor **singleton**. `BaseRunner._cleanup` used to call `executor.shutdown(wait=True)` whenever the runner had created the executor itself (`shutdown_executor or (executor is None)`), which now kills the shared executor out from under any other runner still using it:

```
loky.process_executor.ShutdownExecutorError: cannot schedule new futures after shutdown
```

This broke the Read the Docs build of #497 while executing `tutorial.advanced-topics.md` (a cancelled goal-less runner's cleanup raced with the next runner's `await runner.task`). The race predates #497 on macOS/Windows, where loky was already the default, but docs only execute on Linux so it was never hit.

Idle loky workers shut down on their own after their timeout, and loky cleans up at interpreter exit, so nothing leaks.

## Testing

- Minimal repro (cancel a goal-less runner, then run a second runner) raised `ShutdownExecutorError` before, passes now.
- Full suite passes on Python 3.14.5 (except the pre-existing `test_to_dataframe` failures that also occur on `main`).
- pre-commit passes.