### PR TITLE
Adopt adaptive-triangulation 0.3.1: batched tell_pending, Rust default_loss, and a Rust-backend CI job

### DIFF
--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -26,3 +26,16 @@ jobs:
       run: uv run --group nox nox -e "pytest_min_deps-${{ matrix.python-version }}"
     - name: Test with nox with all dependencies
       run: uv run --group nox nox -e "pytest_all_deps-${{ matrix.python-version }}"
+
+  test-rust-backend:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+    - name: Test with nox with the Rust triangulation backend
+      run: uv run --group nox nox -e pytest_rust_backend

--- a/adaptive/learner/learnerND.py
+++ b/adaptive/learner/learnerND.py
@@ -20,6 +20,7 @@ from adaptive.learner.triangulation_backend import (
     circumsphere,
     point_in_simplex,
     resolve_triangulation_class,
+    rust_default_loss,
     simplex_volume_in_embedding,
 )
 from adaptive.notebook_integration import ensure_holoviews, ensure_plotly
@@ -333,7 +334,9 @@ class LearnerND(BaseLearner):
     ):
         self._triangulation_class = resolve_triangulation_class(triangulation_backend)
         self._vdim = None
-        self.loss_per_simplex = loss_per_simplex or default_loss
+        # Prefer the Rust implementation of the default loss when the Rust
+        # backend is active; it computes the same embedded simplex volume.
+        self.loss_per_simplex = loss_per_simplex or rust_default_loss or default_loss
 
         if hasattr(self.loss_per_simplex, "nth_neighbors"):
             if self.loss_per_simplex.nth_neighbors > 1:
@@ -649,34 +652,45 @@ class LearnerND(BaseLearner):
         if self.tri is None:
             return
 
-        simplex = tuple(simplex or self.tri.locate_point(point))
-        if not simplex:
-            return
-            # Simplex is None if pending point is outside the triangulation,
-            # then you do not have subtriangles
-
-        simplex = tuple(simplex)
-        simplices = [self.tri.vertex_to_simplices[i] for i in simplex]
-        neighbors = set.union(*simplices)
-        # Neighbours also includes the simplex itself
-
-        for simpl in neighbors:
-            _, to_add = self._try_adding_pending_point_to_simplex(point, simpl)
+        for simpl in self._simplices_containing_point(point, simplex):
+            _, to_add = self._add_pending_point_to_simplex(point, simpl)
             if to_add is None:
                 continue
             self._update_subsimplex_losses(simpl, to_add)
 
-    def _try_adding_pending_point_to_simplex(self, point, simplex):
-        # try to insert it
-        if not self.tri.point_in_simplex(point, simplex):
-            return None, None
+    def _simplices_containing_point(self, point, simplex=None):
+        """All simplices of the triangulation containing `point`, found from
+        the `simplex` hint when given."""
+        if hasattr(self.tri, "simplices_containing"):
+            # Rust backend: one call instead of a point_in_simplex loop.
+            return self.tri.simplices_containing(point, simplex=simplex)
 
+        simplex = tuple(simplex or self.tri.locate_point(point))
+        if not simplex:
+            return []
+            # Simplex is empty if the pending point is outside the
+            # triangulation, then you do not have subtriangles
+
+        simplices = [self.tri.vertex_to_simplices[i] for i in simplex]
+        neighbors = set.union(*simplices)
+        # Neighbours also includes the simplex itself
+        return [s for s in neighbors if self.tri.point_in_simplex(point, s)]
+
+    def _add_pending_point_to_simplex(self, point, simplex):
+        """Insert `point` into the subtriangulation of `simplex`, which must
+        contain the point."""
         if simplex not in self._subtriangulations:
             vertices = self.tri.get_vertices(simplex)
             self._subtriangulations[simplex] = self._triangulation_class(vertices)
 
         self._pending_to_simplex[point] = simplex
         return self._subtriangulations[simplex].add_point(point)
+
+    def _try_adding_pending_point_to_simplex(self, point, simplex):
+        # try to insert it
+        if not self.tri.point_in_simplex(point, simplex):
+            return None, None
+        return self._add_pending_point_to_simplex(point, simplex)
 
     def _update_subsimplex_losses(self, simplex, new_subsimplices):
         loss = self._losses[simplex]

--- a/adaptive/learner/triangulation_backend.py
+++ b/adaptive/learner/triangulation_backend.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 
 import os
 
-# Minimal version that is a complete drop-in for the learners
-# (incl. ``get_opposing_vertices`` and pickle/deepcopy support).
-_MIN_RUST_VERSION = (0, 2, 1)
+# Minimal version that is a complete drop-in for the learners: includes the
+# degenerate-simplex fix for curvature losses, plus the batched
+# ``simplices_containing`` query and Rust ``default_loss`` that `LearnerND`
+# uses when this backend is active.
+_MIN_RUST_VERSION = (0, 3, 1)
 
 
 def _rust_version() -> tuple[int, ...] | None:
@@ -119,6 +121,12 @@ if TRIANGULATION_BACKEND == "rust":
         point_in_simplex,
         simplex_volume_in_embedding,
     )
+
+    # The Rust implementation of `adaptive.learner.learnerND.default_loss`,
+    # which `LearnerND` prefers when no loss is given. Defined here (rather
+    # than re-exporting the Python one) to avoid a circular import with
+    # `learnerND`; ``None`` means "use the pure-Python default".
+    from adaptive_triangulation import default_loss as rust_default_loss
 else:
     from adaptive.learner.triangulation import (
         Triangulation,
@@ -132,6 +140,8 @@ else:
         simplex_volume_in_embedding,
     )
 
+    rust_default_loss = None
+
 __all__ = [
     "TRIANGULATION_BACKEND",
     "Triangulation",
@@ -143,5 +153,6 @@ __all__ = [
     "fast_norm",
     "orientation",
     "point_in_simplex",
+    "rust_default_loss",
     "simplex_volume_in_embedding",
 ]

--- a/adaptive/tests/unit/test_triangulation_backend.py
+++ b/adaptive/tests/unit/test_triangulation_backend.py
@@ -122,3 +122,40 @@ def test_learnernd_uses_rust_backend():
             learner.tell(point, learner.function(point))
     assert isinstance(learner.tri, adaptive_triangulation.Triangulation)
     assert learner.npoints >= 50
+
+
+def test_rust_default_loss_matches_backend():
+    if backend.TRIANGULATION_BACKEND == "rust":
+        import adaptive_triangulation
+
+        assert backend.rust_default_loss is adaptive_triangulation.default_loss
+    else:
+        assert backend.rust_default_loss is None
+
+
+def _ring_of_fire(xy):
+    import numpy as np
+
+    x, y = xy
+    a, d = 0.2, 0.5
+    return x + np.exp(-((x**2 + y**2 - d**2) ** 2) / a**4)
+
+
+@pytest.mark.skipif(not rust_is_usable(), reason="needs adaptive-triangulation")
+def test_rust_backend_samples_identical_points():
+    # The batched tell_pending path and the Rust default loss must not change
+    # which points the learner chooses.
+    from adaptive import LearnerND
+
+    learners = {
+        which: LearnerND(
+            _ring_of_fire, bounds=[(-1, 1), (-1, 1)], triangulation_backend=which
+        )
+        for which in ("python", "rust")
+    }
+    for learner in learners.values():
+        for _ in range(200):
+            points, _ = learner.ask(1)
+            for point in points:
+                learner.tell(point, learner.function(point))
+    assert sorted(learners["python"].data) == sorted(learners["rust"].data)

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,6 +28,14 @@ def pytest_all_deps(session: nox.Session) -> None:
 
 
 @nox.session(python="3.13")
+def pytest_rust_backend(session: nox.Session) -> None:
+    """Run the test suite with the Rust triangulation backend required."""
+    session.install(".[test,other,rust]")
+    session.run("coverage", "erase")
+    session.run("pytest", *xdist, env={"ADAPTIVE_TRIANGULATION_BACKEND": "rust"})
+
+
+@nox.session(python="3.13")
 def pytest_typeguard(session: nox.Session) -> None:
     """Run pytest with typeguard."""
     session.install(".[test,other]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 
 [project.optional-dependencies]
 rust = [
-    "adaptive-triangulation>=0.2.1", # Rust-accelerated triangulation backend
+    "adaptive-triangulation>=0.3.1", # Rust-accelerated triangulation backend
 ]
 other = [
     "dill",


### PR DESCRIPTION
## Summary

Follow-up to #493, completing the two items it deferred. [adaptive-triangulation 0.3.1](https://github.com/python-adaptive/adaptive-triangulation/releases/tag/v0.3.1) fixes the known degenerate-simplex divergence (curvature losses crashed on collinear input with the Rust backend), and [0.3.0](https://github.com/python-adaptive/adaptive-triangulation/releases/tag/v0.3.0) added two batched APIs targeting `LearnerND`'s remaining Python hot loops. This PR bumps `_MIN_RUST_VERSION` to `(0, 3, 1)`, adopts both APIs, and adds the deferred Rust-backend CI job.

## Changes

- **Batched `tell_pending`**: distributing a pending point over the simplices that contain it previously looped `tri.point_in_simplex` over every simplex sharing a vertex with the containing simplex (~14 checks per point in 2D, ~70 in 3D, ~96% misses). With the Rust backend this is now one `tri.simplices_containing(point, simplex=hint)` call (feature-detected via `hasattr`, so a directly-passed custom triangulation class keeps working). The pure-Python backend keeps the original loop, refactored into `_simplices_containing_point` + `_add_pending_point_to_simplex` so both paths share the insertion code.
- **Rust `default_loss`**: when the Rust backend is active, `LearnerND` uses `adaptive_triangulation.default_loss` as the default `loss_per_simplex` — the same embedded-simplex-volume computation without the per-simplex Python tuple-splicing. Exposed as `triangulation_backend.rust_default_loss` (`None` on the python backend) to avoid a circular import with `learnerND`. Pickling adds no new constraint: a learner on the Rust backend already references `adaptive_triangulation` objects.
- **CI**: new `pytest_rust_backend` nox session (installs `.[test,other,rust]`, runs the suite with `ADAPTIVE_TRIANGULATION_BACKEND=rust`) and a `test-rust-backend` job in `nox.yml`.
- `rust` extra bumped to `adaptive-triangulation>=0.3.1`; `_MIN_RUST_VERSION = (0, 3, 1)` (0.2.x installs now fall back to the python backend rather than using a version without the degenerate-simplex fix).

## Performance

End-to-end `LearnerND` vs adaptive 1.5.0, both with the Rust backend (best of 3):

| case | 1.5.0 + rust | this PR + rust | speedup |
|---|---:|---:|---:|
| 2D `ring_of_fire`, 3000 pts | 0.46 s | 0.42 s | 1.10× |
| 3D `sphere_of_fire`, 1500 pts | 0.74 s | 0.52 s | **1.42×** |

The gain grows with dimension (vertex stars get bigger). Sampled points are identical between the python and rust backends — asserted by a new test that runs both for 200 points.

## Testing

- Full suite with the Rust backend forced: **294 passed, 0 failures** (the 7 curvature-loss failures documented in #493 are gone with 0.3.1).
- Full suite without adaptive-triangulation installed: 292 passed (rust-specific tests skip).
- New tests: `test_rust_default_loss_matches_backend` (both env configurations) and `test_rust_backend_samples_identical_points`.
- pre-commit (ruff, ruff-format, mypy) passes on the changed files.